### PR TITLE
Refactor AdaptableLayout component

### DIFF
--- a/app/MMB/src/appRegistry/ManageMyBookingPackage.js
+++ b/app/MMB/src/appRegistry/ManageMyBookingPackage.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { AuthContext } from '@kiwicom/mobile-relay';
+import { AdaptableLayout } from '@kiwicom/mobile-shared';
 
 import NavigationStack from '../navigation/NavigationStack';
 
@@ -12,8 +13,10 @@ type Props = {|
 
 export default class ManageMyBookingPackage extends React.Component<Props> {
   render = () => (
-    <AuthContext.Provider accessToken={this.props.accessToken}>
-      <NavigationStack />
-    </AuthContext.Provider>
+    <AdaptableLayout.Provider>
+      <AuthContext.Provider accessToken={this.props.accessToken}>
+        <NavigationStack />
+      </AuthContext.Provider>
+    </AdaptableLayout.Provider>
   );
 }

--- a/app/MMB/src/components/Layout.js
+++ b/app/MMB/src/components/Layout.js
@@ -43,7 +43,7 @@ type Props = {|
  */
 export default function Layout(props: Props) {
   return (
-    <AdaptableLayout
+    <AdaptableLayout.Consumer
       renderOnNarrow={<NarrowLayout menuComponent={props.menuComponent} />}
       renderOnWide={
         <WideLayout

--- a/app/MMB/src/navigation/MMBScreen.js
+++ b/app/MMB/src/navigation/MMBScreen.js
@@ -104,7 +104,7 @@ export default class MMBScreen extends React.Component<Props, State> {
     return (
       <Layout
         menuComponent={
-          <AdaptableLayout
+          <AdaptableLayout.Consumer
             renderOnWide={<MainMenu openMenu={this.changeContentOnTablet} />}
             renderOnNarrow={<MainMenu openMenu={this.openMenuOnMobile} />}
           />

--- a/app/hotels/src/appRegistry/RootComponent.js
+++ b/app/hotels/src/appRegistry/RootComponent.js
@@ -1,23 +1,17 @@
 // @flow
 
 import * as React from 'react';
-import { View, NativeModules } from 'react-native';
+import { NativeModules } from 'react-native';
 import { ConfigContext } from '@kiwicom/mobile-config';
 import {
   Device,
-  type OnLayout,
-  StyleSheet,
   GeolocationContext,
+  AdaptableLayout,
+  type OnLayout,
 } from '@kiwicom/mobile-shared';
 
 import HotelsSearchContext from '../HotelsSearchContext';
 import HotelsFilterContext from '../HotelsFilterContext';
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
 
 type Props = {|
   onBackClicked: () => void,
@@ -44,9 +38,9 @@ export default class RootComponent extends React.Component<Props> {
       <HotelsSearchContext.Provider>
         <HotelsFilterContext.Provider>
           <GeolocationContext.Provider>
-            <View style={styles.container} onLayout={this.emitDimensionChanges}>
+            <AdaptableLayout.Provider>
               {this.props.render(this.onBackClicked)}
-            </View>
+            </AdaptableLayout.Provider>
           </GeolocationContext.Provider>
         </HotelsFilterContext.Provider>
       </HotelsSearchContext.Provider>

--- a/app/hotels/src/map/allHotels/AllHotelsMap.js
+++ b/app/hotels/src/map/allHotels/AllHotelsMap.js
@@ -107,7 +107,7 @@ class AllHotelsMap extends React.Component<PropsWithContext> {
         onStateChange={this.validateCheckinDate}
       >
         <View style={styles.container}>
-          <AdaptableLayout
+          <AdaptableLayout.Consumer
             renderOnNarrow={<FilterStripe currency={currency} />}
           />
           {canSearch ? (

--- a/app/hotels/src/map/allHotels/HotelSwipeList.js
+++ b/app/hotels/src/map/allHotels/HotelSwipeList.js
@@ -122,7 +122,7 @@ class HotelSwipeList extends React.Component<Props, State> {
     );
 
     return (
-      <AdaptableLayout
+      <AdaptableLayout.Consumer
         renderOnWide={
           <View style={[styles.fullWidth, styles.wide]}>{child}</View>
         }

--- a/app/hotels/src/map/singleHotel/BottomSheet.js
+++ b/app/hotels/src/map/singleHotel/BottomSheet.js
@@ -35,7 +35,7 @@ export default class BottomSheet extends React.Component<Props> {
     );
 
     return (
-      <AdaptableLayout
+      <AdaptableLayout.Consumer
         renderOnWide={<View style={styles.wideContainer}>{content}</View>}
         renderOnNarrow={<View style={styles.narrowContainer}>{content}</View>}
       />

--- a/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
+++ b/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
@@ -44,7 +44,7 @@ export default class AllHotelsNavigationScreen extends React.Component<Props> {
 
     function renderHeaderRight() {
       return (
-        <AdaptableLayout
+        <AdaptableLayout.Consumer
           renderOnNarrow={<MapHeaderButton onPress={goToAllHotelsMap} />}
         />
       );
@@ -118,7 +118,7 @@ export default class AllHotelsNavigationScreen extends React.Component<Props> {
   render = () => {
     return (
       <WithBackButtonListener onClick={this.onAndroidBackClicked}>
-        <AdaptableLayout
+        <AdaptableLayout.Consumer
           renderOnWide={this.renderHotelsWithMap()}
           renderOnNarrow={this.renderHotels()}
         />

--- a/app/hotels/src/singleHotel/HotelDetailScreen.js
+++ b/app/hotels/src/singleHotel/HotelDetailScreen.js
@@ -116,7 +116,9 @@ export class HotelDetailScreen extends React.Component<Props, State> {
     return [
       <Layout key="detailLayout">
         <ScrollView>
-          <AdaptableLayout renderOnWide={<View style={styles.marginView} />} />
+          <AdaptableLayout.Consumer
+            renderOnWide={<View style={styles.marginView} />}
+          />
           <Header openGallery={openGallery} hotel={availableHotel.hotel} />
           <HotelInformation
             hotel={availableHotel.hotel}

--- a/app/hotels/src/singleHotel/header/Header.js
+++ b/app/hotels/src/singleHotel/header/Header.js
@@ -133,7 +133,7 @@ export class Header extends React.Component<Props> {
   render = () => {
     const header = this.renderHeader();
     return (
-      <AdaptableLayout
+      <AdaptableLayout.Consumer
         renderOnNarrow={header}
         renderOnWide={<View style={styles.tabletContainer}>{header}</View>}
       />

--- a/app/hotels/src/singleHotel/hotelInformation/HotelInformation.js
+++ b/app/hotels/src/singleHotel/hotelInformation/HotelInformation.js
@@ -50,7 +50,7 @@ export class HotelInformation extends React.Component<Props> {
   render = () => {
     const baseComponent = this.renderBaseComponent();
     return (
-      <AdaptableLayout
+      <AdaptableLayout.Consumer
         renderOnNarrow={baseComponent}
         renderOnWide={
           <View>

--- a/app/hotels/src/singleHotel/hotelInformation/description/Description.js
+++ b/app/hotels/src/singleHotel/hotelInformation/description/Description.js
@@ -89,7 +89,7 @@ export class Description extends React.Component<Props> {
   render = () => {
     const baseComponent = this.renderBaseComponent();
     return (
-      <AdaptableLayout
+      <AdaptableLayout.Consumer
         renderOnNarrow={baseComponent}
         renderOnWide={
           <View style={styles.simpleCardWideWrapper}>

--- a/app/hotels/src/singleHotel/roomList/RoomRow.js
+++ b/app/hotels/src/singleHotel/roomList/RoomRow.js
@@ -136,7 +136,7 @@ export class RoomRow extends React.Component<Props> {
   };
 
   render = () => (
-    <AdaptableLayout
+    <AdaptableLayout.Consumer
       renderOnNarrow={this.renderRow(false)}
       renderOnWide={this.renderRow(true)}
     />

--- a/app/shared/src/popup/Popup.js
+++ b/app/shared/src/popup/Popup.js
@@ -34,7 +34,7 @@ export default class Popup extends React.Component<Props> {
         onBackdropPress={this.onClose}
         onRequestClose={this.onClose}
       >
-        <AdaptableLayout
+        <AdaptableLayout.Consumer
           renderOnWide={
             <View
               style={[styles.contentContainer, styles.wideContentContainer]}

--- a/app/shared/src/view/AdaptableLayout.js
+++ b/app/shared/src/view/AdaptableLayout.js
@@ -1,19 +1,50 @@
 // @flow
 
 import * as React from 'react';
+import { View } from 'react-native';
 
 import Device from '../Device';
+import StyleSheet from '../PlatformStyleSheet';
+import type { OnLayout } from '../../index';
 
-type Props = {|
-  renderOnWide?: React.Node,
-  renderOnNarrow?: React.Node,
-|};
+const AdaptableLayoutContext = React.createContext({
+  isSet: false,
+});
 
-type State = {|
-  wideLayout: boolean,
-|};
+class Provider extends React.Component<
+  {| children: React.Node |},
+  {| isSet: boolean |},
+> {
+  state = {
+    isSet: true,
+  };
 
-export default class AdaptableLayout extends React.Component<Props, State> {
+  emitDimensionChanges = (event: OnLayout) => {
+    const { width, height } = event.nativeEvent.layout;
+    Device.emitDimensionChanges(height, width);
+  };
+
+  render = () => (
+    <View
+      style={styleSheet.providerWrapper}
+      onLayout={this.emitDimensionChanges}
+    >
+      <AdaptableLayoutContext.Provider value={this.state}>
+        {this.props.children}
+      </AdaptableLayoutContext.Provider>
+    </View>
+  );
+}
+
+class Consumer extends React.Component<
+  {|
+    renderOnWide?: React.Node,
+    renderOnNarrow?: React.Node,
+  |},
+  {|
+    wideLayout: boolean,
+  |},
+> {
   unsubscribeDimensionListener: Function = () => {};
 
   state = {
@@ -35,15 +66,44 @@ export default class AdaptableLayout extends React.Component<Props, State> {
   };
 
   render = () => {
-    if (this.state.wideLayout === true && this.props.renderOnWide) {
-      return this.props.renderOnWide;
-    } else if (this.state.wideLayout === false && this.props.renderOnNarrow) {
-      return this.props.renderOnNarrow;
-    }
-
     // may return nothing:
     // 1. renderOnWide set but we have narrow layout
     // 2. renderOnNarrow set but we have wide layout
-    return null;
+    let children = null;
+
+    if (this.state.wideLayout === true && this.props.renderOnWide) {
+      children = this.props.renderOnWide;
+    } else if (this.state.wideLayout === false && this.props.renderOnNarrow) {
+      children = this.props.renderOnNarrow;
+    }
+
+    return (
+      <AdaptableLayoutContext.Consumer>
+        {contextValue => {
+          if (contextValue.isSet === false) {
+            if (process.env.NODE_ENV !== 'test') {
+              throw new Error(
+                'AdaptableLayout has been called in wrong context. You have to ' +
+                  'use "AdaptableLayout.Provider" on the root level first ' +
+                  "otherwise it won't work.",
+              );
+            }
+          }
+
+          return children;
+        }}
+      </AdaptableLayoutContext.Consumer>
+    );
   };
 }
+
+export default {
+  Provider,
+  Consumer,
+};
+
+const styleSheet = StyleSheet.create({
+  providerWrapper: {
+    flex: 1,
+  },
+});

--- a/app/shared/src/view/__tests__/AdaptableLayout.narrow.test.js
+++ b/app/shared/src/view/__tests__/AdaptableLayout.narrow.test.js
@@ -19,18 +19,22 @@ const ThrowsError = () => {
 it('renders narrow components', () => {
   expect(
     Renderer.create(
-      <AdaptableLayout
-        renderOnWide={<ThrowsError />}
-        renderOnNarrow={<RendersCorrectly />}
-      />,
-    ).toJSON(),
-  ).toBe('I am going to render without any problems...');
+      <AdaptableLayout.Provider>
+        <AdaptableLayout.Consumer
+          renderOnWide={<ThrowsError />}
+          renderOnNarrow={<RendersCorrectly />}
+        />
+      </AdaptableLayout.Provider>,
+    ),
+  ).toMatchSnapshot();
 });
 
-it('renders null if there is no narrow layout', () => {
+it('renders empty element if there is no narrow layout', () => {
   expect(
     Renderer.create(
-      <AdaptableLayout renderOnWide={<ThrowsError />} />,
-    ).toJSON(),
-  ).toBeNull();
+      <AdaptableLayout.Provider>
+        <AdaptableLayout.Consumer renderOnWide={<ThrowsError />} />
+      </AdaptableLayout.Provider>,
+    ),
+  ).toMatchSnapshot();
 });

--- a/app/shared/src/view/__tests__/AdaptableLayout.test.js
+++ b/app/shared/src/view/__tests__/AdaptableLayout.test.js
@@ -5,6 +5,23 @@ import Renderer from 'react-test-renderer';
 
 import AdaptableLayout from '../AdaptableLayout';
 
-it('renders null without props', () => {
-  expect(Renderer.create(<AdaptableLayout />).toJSON()).toBeNull();
+it('renders empty element without props', () => {
+  expect(
+    Renderer.create(
+      <AdaptableLayout.Provider>
+        <AdaptableLayout.Consumer />
+      </AdaptableLayout.Provider>,
+    ),
+  ).toMatchSnapshot();
+});
+
+it('throw error when called without provider', () => {
+  const NODE_ENV = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'something else than test';
+
+  expect(() =>
+    Renderer.create(<AdaptableLayout.Consumer />),
+  ).toThrowErrorMatchingSnapshot();
+
+  process.env.NODE_ENV = NODE_ENV;
 });

--- a/app/shared/src/view/__tests__/AdaptableLayout.wide.test.js
+++ b/app/shared/src/view/__tests__/AdaptableLayout.wide.test.js
@@ -19,18 +19,22 @@ const ThrowsError = () => {
 it('renders wide components', () => {
   expect(
     Renderer.create(
-      <AdaptableLayout
-        renderOnWide={<RendersCorrectly />}
-        renderOnNarrow={<ThrowsError />}
-      />,
-    ).toJSON(),
-  ).toBe('I am going to render without any problems...');
+      <AdaptableLayout.Provider>
+        <AdaptableLayout.Consumer
+          renderOnWide={<RendersCorrectly />}
+          renderOnNarrow={<ThrowsError />}
+        />
+      </AdaptableLayout.Provider>,
+    ),
+  ).toMatchSnapshot();
 });
 
-it('renders null if there is no wide layout', () => {
+it('renders empty element if there is no wide layout', () => {
   expect(
     Renderer.create(
-      <AdaptableLayout renderOnNarrow={<ThrowsError />} />,
-    ).toJSON(),
-  ).toBeNull();
+      <AdaptableLayout.Provider>
+        <AdaptableLayout.Consumer renderOnNarrow={<ThrowsError />} />
+      </AdaptableLayout.Provider>,
+    ),
+  ).toMatchSnapshot();
 });

--- a/app/shared/src/view/__tests__/__snapshots__/AdaptableLayout.narrow.test.js.snap
+++ b/app/shared/src/view/__tests__/__snapshots__/AdaptableLayout.narrow.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders empty element if there is no narrow layout 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+/>
+`;
+
+exports[`renders narrow components 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  I am going to render without any problems...
+</View>
+`;

--- a/app/shared/src/view/__tests__/__snapshots__/AdaptableLayout.test.js.snap
+++ b/app/shared/src/view/__tests__/__snapshots__/AdaptableLayout.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders empty element without props 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+/>
+`;
+
+exports[`throw error when called without provider 1`] = `"AdaptableLayout has been called in wrong context. You have to use \\"AdaptableLayout.Provider\\" on the root level first otherwise it won't work."`;

--- a/app/shared/src/view/__tests__/__snapshots__/AdaptableLayout.wide.test.js.snap
+++ b/app/shared/src/view/__tests__/__snapshots__/AdaptableLayout.wide.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders empty element if there is no wide layout 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+/>
+`;
+
+exports[`renders wide components 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  I am going to render without any problems...
+</View>
+`;


### PR DESCRIPTION
I discovered an error in our MMB where AdaptableLayout didn't work
because we didn't set it in the right context. So I refactored it
completely in order to throw appropriate error (so it should never
happen again). Now it's necessary to use Provider-Consumer combo similar
 to the React context API.