### PR TITLE
Dependencies: upgrade 'react-native-modal' to the latest version

### DIFF
--- a/app/shared/package.json
+++ b/app/shared/package.json
@@ -9,7 +9,7 @@
     "@kiwicom/react-native-native-modules": "^0.1.25",
     "@ptomasroos/react-native-multi-slider": "^0.0.12",
     "react-native-image-progress": "^1.1.0",
-    "react-native-modal": "^5.4.0",
+    "react-native-modal": "^6.0.0",
     "react-native-vector-icons": "^4.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5525,9 +5525,9 @@ react-native-maps@^0.21.0:
     babel-plugin-module-resolver "^2.3.0"
     babel-preset-react-native "1.9.0"
 
-react-native-modal@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-5.4.0.tgz#95f70b5d68e08824951cd11038b9db2d6fdb9962"
+react-native-modal@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-6.0.0.tgz#72b829454cde207848e4323a96a440c152f7508e"
   dependencies:
     prop-types "^15.6.1"
     react-native-animatable "^1.2.4"


### PR DESCRIPTION
One at the time. It should be without BC breaks but it's a major upgrade.