### PR TITLE
Unify Relay imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,11 @@ module.exports = {
             message:
               "Please use '@kiwicom/mobile-navigation' package instead.",
           },
+          {
+            name: 'react-relay',
+            message:
+              "Please use '@kiwicom/mobile-relay' package instead.",
+          },
         ],
       },
     ],

--- a/app/MMB/src/list/FlightList.js
+++ b/app/MMB/src/list/FlightList.js
@@ -2,9 +2,9 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { graphql, createFragmentContainer } from 'react-relay';
-import idx from 'idx';
+import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import { StyleSheet, Device, AdaptableLayout } from '@kiwicom/mobile-shared';
+import idx from 'idx';
 
 import OneWayFlight from './OneWayFlight';
 import ReturnFlight from './ReturnFlight';

--- a/app/MMB/src/list/FlightListContainer.js
+++ b/app/MMB/src/list/FlightListContainer.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from 'react';
-import { graphql, createRefetchContainer } from 'react-relay';
 import { ScrollView, RefreshControl, View } from 'react-native';
 import {
   Text,
@@ -10,7 +9,11 @@ import {
   AdaptableLayout,
 } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
-import type { RelayRefetchProp } from '@kiwicom/mobile-relay';
+import {
+  graphql,
+  createRefetchContainer,
+  type RelayRefetchProp,
+} from '@kiwicom/mobile-relay';
 
 import FlightList from './FlightList';
 import type { FlightListContainer_future as FutureFlightType } from './__generated__/FlightListContainer_future.graphql';

--- a/app/MMB/src/list/Flights.js
+++ b/app/MMB/src/list/Flights.js
@@ -1,8 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PrivateApiRenderer } from '@kiwicom/mobile-relay';
-import { graphql } from 'react-relay';
+import { graphql, PrivateApiRenderer } from '@kiwicom/mobile-relay';
 
 import type { FlightsQueryResponse } from './__generated__/FlightsQuery.graphql';
 import FlightListContainer from './FlightListContainer';

--- a/app/MMB/src/list/MulticityFlight.js
+++ b/app/MMB/src/list/MulticityFlight.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { graphql, createFragmentContainer } from 'react-relay';
+import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import idx from 'idx';
 
 import CityImage from './cityImage/CityImage';

--- a/app/MMB/src/list/OneWayFlight.js
+++ b/app/MMB/src/list/OneWayFlight.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { graphql, createFragmentContainer } from 'react-relay';
+import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import idx from 'idx';
 
 import CityImage from './cityImage/CityImage';

--- a/app/MMB/src/list/ReturnFlight.js
+++ b/app/MMB/src/list/ReturnFlight.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { graphql, createFragmentContainer } from 'react-relay';
+import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import idx from 'idx';
 
 import CityImage from './cityImage/CityImage';

--- a/app/MMB/src/list/cityImage/CityImage.js
+++ b/app/MMB/src/list/cityImage/CityImage.js
@@ -9,8 +9,8 @@ import {
   Touchable,
 } from '@kiwicom/mobile-shared';
 import { View } from 'react-native';
-import { graphql, createFragmentContainer } from 'react-relay';
 import { withNavigation } from 'react-navigation';
+import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import type { NavigationType } from '@kiwicom/mobile-navigation';
 import idx from 'idx';
 

--- a/app/MMB/src/list/cityImage/DateAndPassengerCount.js
+++ b/app/MMB/src/list/cityImage/DateAndPassengerCount.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { Text, StyleSheet, Icon, Color } from '@kiwicom/mobile-shared';
 import { Translation, DateFormatter } from '@kiwicom/mobile-localization';
-import { graphql, createFragmentContainer } from 'react-relay';
+import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import idx from 'idx';
 
 import type { DateAndPassengerCount_departure as DepartureType } from './__generated__/DateAndPassengerCount_departure.graphql';

--- a/app/MMB/src/list/cityImage/FromToRow.js
+++ b/app/MMB/src/list/cityImage/FromToRow.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { Text, StyleSheet, Color } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
-import { graphql, createFragmentContainer } from 'react-relay';
+import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import idx from 'idx';
 
 import TravelTypeIcon from './TravelTypeIcon';

--- a/app/MMB/src/menu/Deeplink.js
+++ b/app/MMB/src/menu/Deeplink.js
@@ -1,9 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { graphql } from 'react-relay';
 import { WebView } from '@kiwicom/mobile-shared';
-import { PrivateApiRenderer } from '@kiwicom/mobile-relay';
+import { graphql, PrivateApiRenderer } from '@kiwicom/mobile-relay';
 import idx from 'idx';
 
 import type {

--- a/app/MMB/src/menu/Invoice.js
+++ b/app/MMB/src/menu/Invoice.js
@@ -1,8 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { graphql } from 'react-relay';
-import { PrivateApiRenderer } from '@kiwicom/mobile-relay';
+import { graphql, PrivateApiRenderer } from '@kiwicom/mobile-relay';
 import { GeneralError } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
 import PdfViewer from '@kiwicom/mobile-pdf';

--- a/app/core/src/components/authentication/mutation/Login.js
+++ b/app/core/src/components/authentication/mutation/Login.js
@@ -1,7 +1,6 @@
 // @flow
 
-import { graphql } from 'react-relay';
-import { commitMutation } from '@kiwicom/mobile-relay';
+import { graphql, commitMutation } from '@kiwicom/mobile-relay';
 
 import type {
   LoginMutationVariables,

--- a/app/hotels/package.json
+++ b/app/hotels/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@kiwicom/mobile-config": "^0",
     "@kiwicom/mobile-localization": "^0",
+    "@kiwicom/mobile-relay": "^0",
     "@kiwicom/mobile-shared": "^0",
     "geolib": "^2.0.24",
     "idx": "^2.2.0",

--- a/app/hotels/src/allHotels/AllHotelsSearch.js
+++ b/app/hotels/src/allHotels/AllHotelsSearch.js
@@ -1,8 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { graphql, PublicApiRenderer } from '@kiwicom/mobile-relay';
 
 import AllHotelsSearchList from './AllHotelsSearchList';
 import { handleOpenSingleHotel } from '../singleHotel';

--- a/app/hotels/src/allHotels/AllHotelsSearchList.js
+++ b/app/hotels/src/allHotels/AllHotelsSearchList.js
@@ -2,10 +2,13 @@
 
 import * as React from 'react';
 import idx from 'idx';
-import { createPaginationContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
 import { Logger, GeneralError } from '@kiwicom/mobile-shared';
-import type { RelayPaginationProp } from '@kiwicom/mobile-relay';
+import {
+  createPaginationContainer,
+  graphql,
+  type RelayPaginationProp,
+} from '@kiwicom/mobile-relay';
 import { Translation } from '@kiwicom/mobile-localization';
 
 import HotelsSearchContext from '../HotelsSearchContext';

--- a/app/hotels/src/allHotels/AllHotelsSearchRow.js
+++ b/app/hotels/src/allHotels/AllHotelsSearchRow.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { SimpleCard, NetworkImage, StyleSheet } from '@kiwicom/mobile-shared';
 
 import HotelTitle from './HotelTitle';

--- a/app/hotels/src/allHotels/HotelDistance.js
+++ b/app/hotels/src/allHotels/HotelDistance.js
@@ -1,10 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
-import idx from 'idx';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { StyleSheet, Text, Color } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import type { HotelDistance_hotel } from './__generated__/HotelDistance_hotel.graphql';
 

--- a/app/hotels/src/allHotels/HotelReviewScore.js
+++ b/app/hotels/src/allHotels/HotelReviewScore.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { AdaptableBadge, StyleSheet, Color } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
 

--- a/app/hotels/src/allHotels/HotelTitle.js
+++ b/app/hotels/src/allHotels/HotelTitle.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Color, Price, Stars, Text, StyleSheet } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
 

--- a/app/hotels/src/allHotels/searchForm/locationPicker/LocationPicker.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/LocationPicker.js
@@ -8,8 +8,7 @@ import {
   TextInput,
   WithStorage,
 } from '@kiwicom/mobile-shared';
-import { PublicApiRenderer } from '@kiwicom/mobile-relay';
-import { graphql } from 'react-relay';
+import { graphql, PublicApiRenderer } from '@kiwicom/mobile-relay';
 
 import RecentSearches from './RecentSearches';
 import SuggestionList from './SuggestionList';

--- a/app/hotels/src/allHotels/searchForm/locationPicker/SuggestionList.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/SuggestionList.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { FlatList, View, Keyboard } from 'react-native';
 import idx from 'idx';
 import { StyleSheet } from '@kiwicom/mobile-shared';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 
 import SuggestionListItem from './SuggestionListItem';
 import type { SuggestionList_data } from './__generated__/SuggestionList_data.graphql';

--- a/app/hotels/src/map/Address.js
+++ b/app/hotels/src/map/Address.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Color, Icon, StyleSheet, Text } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
 

--- a/app/hotels/src/map/HotelDetailPreview.js
+++ b/app/hotels/src/map/HotelDetailPreview.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
 import {
   StyleSheet,
@@ -10,6 +9,7 @@ import {
   Price,
   Text,
 } from '@kiwicom/mobile-shared';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Translation } from '@kiwicom/mobile-localization';
 import idx from 'idx';
 

--- a/app/hotels/src/map/allHotels/AllHotelsMap.js
+++ b/app/hotels/src/map/allHotels/AllHotelsMap.js
@@ -2,8 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { graphql, PublicApiRenderer } from '@kiwicom/mobile-relay';
 import {
   StyleSheet,
   AdaptableLayout,

--- a/app/hotels/src/map/allHotels/HotelSwipeItem.js
+++ b/app/hotels/src/map/allHotels/HotelSwipeItem.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { TouchableWithoutFeedback, View } from 'react-native';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import idx from 'idx';
 
 import HotelDetailPreview from '../HotelDetailPreview';

--- a/app/hotels/src/map/allHotels/HotelSwipeList.js
+++ b/app/hotels/src/map/allHotels/HotelSwipeList.js
@@ -2,16 +2,16 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { createFragmentContainer, graphql } from 'react-relay';
 import Carousel from 'react-native-snap-carousel';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import {
   BottomSheet,
   Device,
   StyleSheet,
   AdaptableLayout,
 } from '@kiwicom/mobile-shared';
-import idx from 'idx';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import HotelSwipeItem from './HotelSwipeItem';
 import Address from '../Address';

--- a/app/hotels/src/map/allHotels/MapScreen.js
+++ b/app/hotels/src/map/allHotels/MapScreen.js
@@ -2,9 +2,9 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { createFragmentContainer, graphql } from 'react-relay';
-import idx from 'idx';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { StyleSheet } from '@kiwicom/mobile-shared';
+import idx from 'idx';
 
 import MapView from './MapView';
 import HotelSwipeList from './HotelSwipeList';

--- a/app/hotels/src/map/allHotels/MapView.js
+++ b/app/hotels/src/map/allHotels/MapView.js
@@ -2,9 +2,9 @@
 
 import idx from 'idx';
 import * as React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
 import MapView from 'react-native-maps';
 import { orderByDistance, getBounds } from 'geolib';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import PriceMarker from './PriceMarker';

--- a/app/hotels/src/map/allHotels/PriceMarker.js
+++ b/app/hotels/src/map/allHotels/PriceMarker.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Color, Price, StyleSheet } from '@kiwicom/mobile-shared';
 
 import type { PriceMarker as PriceMarkerData } from './__generated__/PriceMarker.graphql';

--- a/app/hotels/src/map/singleHotel/AdditionalInfo.js
+++ b/app/hotels/src/map/singleHotel/AdditionalInfo.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import BottomSheet from './BottomSheet';

--- a/app/hotels/src/map/singleHotel/MapView.js
+++ b/app/hotels/src/map/singleHotel/MapView.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
 import NativeMapView from 'react-native-maps';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { DropMarker, StyleSheet } from '@kiwicom/mobile-shared';
 
 import type { MapView_hotel } from './__generated__/MapView_hotel.graphql';

--- a/app/hotels/src/map/singleHotel/SingleHotelMapScreen.js
+++ b/app/hotels/src/map/singleHotel/SingleHotelMapScreen.js
@@ -3,8 +3,7 @@
 import * as React from 'react';
 import idx from 'idx';
 import { View } from 'react-native';
-import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { graphql, PublicApiRenderer } from '@kiwicom/mobile-relay';
 import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import type { AvailableHotelSearchInput } from '../../singleHotel/AvailableHotelSearchInput';

--- a/app/hotels/src/singleHotel/HotelDetailScreen.js
+++ b/app/hotels/src/singleHotel/HotelDetailScreen.js
@@ -9,9 +9,9 @@ import {
   AdaptableLayout,
   StyleSheet,
 } from '@kiwicom/mobile-shared';
-import { createFragmentContainer, graphql } from 'react-relay';
-import idx from 'idx';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import Header from './header/Header';
 import HotelInformation from './hotelInformation/HotelInformation';

--- a/app/hotels/src/singleHotel/bookNow/BookNow.js
+++ b/app/hotels/src/singleHotel/bookNow/BookNow.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { StyleSheet, Color, Touchable, Price } from '@kiwicom/mobile-shared';
 import idx from 'idx';
 

--- a/app/hotels/src/singleHotel/header/Header.js
+++ b/app/hotels/src/singleHotel/header/Header.js
@@ -12,9 +12,9 @@ import {
   Device,
   BlackToAlpha as gradient,
 } from '@kiwicom/mobile-shared';
-import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import GalleryButton from '../galleryButton/GalleryButton';
 import Rating from './Rating';

--- a/app/hotels/src/singleHotel/hotelInformation/HotelInformation.js
+++ b/app/hotels/src/singleHotel/hotelInformation/HotelInformation.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { AdaptableLayout, StyleSheet, Color } from '@kiwicom/mobile-shared';
 
 import Location from './location/Location';

--- a/app/hotels/src/singleHotel/hotelInformation/description/Description.js
+++ b/app/hotels/src/singleHotel/hotelInformation/description/Description.js
@@ -2,8 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import {
   Text,
   SimpleCard,
@@ -12,6 +11,7 @@ import {
   ReadMore,
 } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import type { Description_hotel } from './__generated__/Description_hotel.graphql';
 import Facilities from './Facilities';

--- a/app/hotels/src/singleHotel/hotelInformation/description/Facilities.js
+++ b/app/hotels/src/singleHotel/hotelInformation/description/Facilities.js
@@ -2,8 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import {
   StyleSheet,
   Color,
@@ -12,6 +11,7 @@ import {
   Touchable,
 } from '@kiwicom/mobile-shared';
 import { Translation, TranslationFragment } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import type { Facilities_facilities } from './__generated__/Facilities_facilities.graphql';
 

--- a/app/hotels/src/singleHotel/hotelInformation/location/Location.js
+++ b/app/hotels/src/singleHotel/hotelInformation/location/Location.js
@@ -11,9 +11,9 @@ import {
   Touchable,
   Color,
 } from '@kiwicom/mobile-shared';
-import idx from 'idx';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import gradient from './white-to-alpha-horizontal.png';
 import type { Location_hotel } from './__generated__/Location_hotel.graphql';

--- a/app/hotels/src/singleHotel/index.js
+++ b/app/hotels/src/singleHotel/index.js
@@ -1,8 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { graphql, PublicApiRenderer } from '@kiwicom/mobile-relay';
 
 import HotelDetailScreen from './HotelDetailScreen';
 import type { Image } from '../gallery/GalleryGrid';

--- a/app/hotels/src/singleHotel/roomList/BeddingInfo.js
+++ b/app/hotels/src/singleHotel/roomList/BeddingInfo.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import {
   StyleSheet,
   Text,

--- a/app/hotels/src/singleHotel/roomList/RoomBadges.js
+++ b/app/hotels/src/singleHotel/roomList/RoomBadges.js
@@ -1,10 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
-import idx from 'idx';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { AdaptableBadge, StyleSheet, TextIcon } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import type { RoomBadges_availableRoom as RoomBadgesTypes } from './__generated__/RoomBadges_availableRoom.graphql';
 

--- a/app/hotels/src/singleHotel/roomList/RoomDescription.js
+++ b/app/hotels/src/singleHotel/roomList/RoomDescription.js
@@ -2,10 +2,10 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { createFragmentContainer, graphql } from 'react-relay';
-import idx from 'idx';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Text, StyleSheet, Color, ReadMore } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
+import idx from 'idx';
 
 import type { RoomDescription_room as RoomDescriptionType } from './__generated__/RoomDescription_room.graphql';
 

--- a/app/hotels/src/singleHotel/roomList/RoomList.js
+++ b/app/hotels/src/singleHotel/roomList/RoomList.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { StyleSheet, Text, Color } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
 

--- a/app/hotels/src/singleHotel/roomList/RoomRow.js
+++ b/app/hotels/src/singleHotel/roomList/RoomRow.js
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   AdaptableLayout,
 } from '@kiwicom/mobile-shared';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 
 import RoomPicker from '../roomPicker/RoomPicker';
 import RoomImage from './RoomImage';

--- a/app/hotels/src/singleHotel/roomList/RoomRowTitle.js
+++ b/app/hotels/src/singleHotel/roomList/RoomRowTitle.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Text, TextIcon, StyleSheet, Color } from '@kiwicom/mobile-shared';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
 import { Translation } from '@kiwicom/mobile-localization';
 import idx from 'idx';
 

--- a/app/relay/index.js
+++ b/app/relay/index.js
@@ -1,13 +1,25 @@
 // @flow
 
 import * as React from 'react';
-import Relay from 'react-relay';
+import Relay from 'react-relay'; // eslint-disable-line no-restricted-imports
 
 import PublicEnvironment from './src/PublicEnvironment';
 
+export {
+  QueryRenderer,
+  graphql,
+  createFragmentContainer,
+  createPaginationContainer,
+  createRefetchContainer,
+} from 'react-relay';
 export { default as PublicApiRenderer } from './src/PublicApiRenderer';
 export { default as PrivateApiRenderer } from './src/PrivateApiRenderer';
 export { default as AuthContext } from './src/AuthContext';
+
+export const commitMutation = (config: CommitMutationConfig) =>
+  Relay.commitMutation(PublicEnvironment.getEnvironment(() => {}), config);
+
+// Flow types:
 
 type CommitMutationConfig = {|
   // please extend this type if needed
@@ -15,9 +27,6 @@ type CommitMutationConfig = {|
   variables: Object,
   onCompleted: Function,
 |};
-
-export const commitMutation = (config: CommitMutationConfig) =>
-  Relay.commitMutation(PublicEnvironment.getEnvironment(() => {}), config);
 
 export type QueryRendererProps = {|
   query: string,

--- a/app/relay/src/QueryRenderer.js
+++ b/app/relay/src/QueryRenderer.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { QueryRenderer as OriginalQueryRenderer } from 'react-relay';
+import { QueryRenderer as OriginalQueryRenderer } from '@kiwicom/mobile-relay';
 import {
   FullPageLoading,
   GeneralError,


### PR DESCRIPTION
Instead of importing things from two different places:

```
import { graphql } from 'react-relay';
import { commitMutation } from '@kiwicom/mobile-relay';
```

We will not import them from one namespace:

```
import { graphql, commitMutation } from '@kiwicom/mobile-relay';
```