### PR TITLE
Not showing status open as ordered service

### DIFF
--- a/app/MMB/src/scenes/flightServices/FlightServicesMenuGroup.js
+++ b/app/MMB/src/scenes/flightServices/FlightServicesMenuGroup.js
@@ -106,13 +106,21 @@ export class FlightServicesMenuGroup extends React.Component<Props, State> {
   getOrderedAndNotOrderedServices = () => {
     const bookedServices =
       idx(this.props.bookedServices, _ => _.bookedServices) || [];
-    const categories = bookedServices.map(item => idx(item, _ => _.category));
 
+    // A service is considered to be ordered if it is a booked service and status is not open
+    // Here we are extracting the category of each ordered service with status not equal to open
+    const orderedCategories = bookedServices
+      .filter(item => idx(item, _ => _.status) !== 'OPEN')
+      .map(item => idx(item, _ => _.category));
+
+    // Filtering offered ordered services against extracted ordered categories
     const ordered = offeredFlightServices.filter(item =>
-      categories.includes(item.key),
+      orderedCategories.includes(item.key),
     );
+
+    // Ordered services whose category is not in the ordredCategories item, hence not ordered service
     const rest = offeredFlightServices.filter(
-      item => !categories.includes(item.key),
+      item => !orderedCategories.includes(item.key),
     );
 
     return { ordered, rest };

--- a/app/MMB/src/scenes/flightServices/__tests__/FlightServicesMenuGroup.test.js
+++ b/app/MMB/src/scenes/flightServices/__tests__/FlightServicesMenuGroup.test.js
@@ -1,0 +1,68 @@
+// @flow
+
+import * as React from 'react';
+import { Translation } from '@kiwicom/mobile-localization';
+import { TextIcon } from '@kiwicom/mobile-shared';
+
+import { FlightServicesMenuGroup } from '../FlightServicesMenuGroup';
+
+it('should split ordered services from not ordered services', () => {
+  // $FlowExpectedError: Passing just props needed to test this method
+  const Component = new FlightServicesMenuGroup({
+    bookedServices: {
+      bookedServices: [
+        {
+          status: 'CONFIRMED',
+          category: 'BAGS',
+        },
+        {
+          status: 'OPEN',
+          category: 'TRAVELLING_WITH_PETS',
+        },
+      ],
+    },
+  });
+
+  expect(Component.getOrderedAndNotOrderedServices()).toEqual({
+    ordered: [
+      {
+        key: 'BAGS',
+        title: <Translation id="mmb.flight_services.additional_baggage" />,
+        routeName: 'mmb.flight_services.checked_baggage',
+        icon: <TextIcon code="&#xe071;" />,
+      },
+    ],
+    rest: [
+      {
+        key: 'ALLOCATED_SEATING',
+        title: <Translation id="mmb.flight_services.allocated_seating" />,
+        routeName: 'mmb.flight_services.allocated_seating',
+        icon: <TextIcon code="&#xe02a;" />,
+      },
+      {
+        key: 'SPORTS_EQUIPMENT',
+        title: <Translation id="mmb.flight_services.sports_equipment" />,
+        routeName: 'mmb.flight_services.sports_equipment',
+        icon: <TextIcon code="&#xe089;" />,
+      },
+      {
+        key: 'MUSICAL_EQUIPMENT',
+        title: <Translation id="mmb.flight_services.musical_equipment" />,
+        routeName: 'mmb.flight_services.musical_equipment',
+        icon: <TextIcon code="&#xe086;" />,
+      },
+      {
+        key: 'SPECIAL_ASSISTANCE',
+        title: <Translation id="mmb.flight_services.special_assistance" />,
+        routeName: 'mmb.flight_services.special_assistance',
+        icon: <TextIcon code="&#xe088;" />,
+      },
+      {
+        key: 'TRAVELLING_WITH_PETS',
+        title: <Translation id="mmb.flight_services.traveling_with_pets" />,
+        routeName: 'mmb.flight_services.pets',
+        icon: <TextIcon code="&#xe043;" />,
+      },
+    ],
+  });
+});


### PR DESCRIPTION
closes #522 

From specs: 
`Ordered services are displayed only if the final_status of the services is "closed", "pending" or "confirmed"`



