### PR TITLE
Shared bridge

### DIFF
--- a/ios/RNKiwiMobile/RNKiwiConstants.h
+++ b/ios/RNKiwiMobile/RNKiwiConstants.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@class RNKiwiConstants;
+
+@interface RNKiwiConstants: NSObject;
+
++ (NSURL *)hotelsBundle;
+
+@end

--- a/ios/RNKiwiMobile/RNKiwiConstants.m
+++ b/ios/RNKiwiMobile/RNKiwiConstants.m
@@ -1,0 +1,16 @@
+// Constants file
+
+#import "RNKiwiConstants.h"
+
+@implementation RNKiwiConstants
+
+/**
+ * Before adding any new bundle here, first we need to add it in
+ * Build Phases -> Bundle React Native dependencies
+ */
+
++ (NSURL *)hotelsBundle {
+  return [[NSBundle bundleForClass:[self class]] URLForResource:@"hotels" withExtension:@"jsbundle"];
+}
+
+@end

--- a/ios/RNKiwiMobile/RNKiwiMobile.h
+++ b/ios/RNKiwiMobile/RNKiwiMobile.h
@@ -12,4 +12,5 @@ FOUNDATION_EXPORT const unsigned char RNKiwiMobileVersionString[];
 #import "RNKiwiViewControllerFlowDelegate.h"
 #import "RNKiwiTranslationProvider.h"
 #import "RNKiwiCurrencyManager.h"
-
+#import "RNKiwiSharedBridge.h"
+#import "RNKiwiConstants.h"

--- a/ios/RNKiwiMobile/RNKiwiOptions.h
+++ b/ios/RNKiwiMobile/RNKiwiOptions.h
@@ -13,12 +13,14 @@
  */
 - (NSString *)moduleName;
 
-@optional
 /**
- * Optional location of the Javascript code to run. Do not provide this in production
- * mode
+ * Location of the Javascript code to run. You can use localhost (on dev for writing JS)
+ * or you can use some of the exposed constants like:
+ *
+ *  - (NSString *)jsCodeLocation {
+ *    return RNKiwiConstants.hotelsBundle;
+ *  }
  */
 - (NSURL *)jsCodeLocation;
 
 @end
-

--- a/ios/RNKiwiMobile/RNKiwiSharedBridge.h
+++ b/ios/RNKiwiMobile/RNKiwiSharedBridge.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import "RNKiwiOptions.h"
+
+@class RCTBridge;
+
+@interface RNKiwiSharedBridge : NSObject
+
++ (RNKiwiSharedBridge*)sharedInstance;
+- (void)initBridgeWithOptions:(id<RNKiwiOptions>)options;
+- (RCTBridge *)bridgeForOptions:(id<RNKiwiOptions>)options;
+
+@end

--- a/ios/RNKiwiMobile/RNKiwiSharedBridge.m
+++ b/ios/RNKiwiMobile/RNKiwiSharedBridge.m
@@ -1,0 +1,53 @@
+#import "RNKiwiSharedBridge.h"
+#import "RNKiwiOptions.h"
+#import <React/RCTBridge.h>
+#import <React/RCTRootView.h>
+
+@interface RNKiwiSharedBridge()
+
+@property (nonatomic, strong) NSMutableDictionary<NSString*,RCTBridge*> *bridges;
+
+@end
+
+@implementation RNKiwiSharedBridge
+
++ (id)sharedInstance {
+  static dispatch_once_t pred = 0;
+  __strong static id _sharedObject = nil;
+  dispatch_once(&pred, ^{
+    _sharedObject = [[self alloc] init];
+  });
+  return _sharedObject;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _bridges = [NSMutableDictionary new];
+  }
+  return self;
+}
+
+- (NSURL *)resolveBundleURL:(id<RNKiwiOptions>)options {
+  return [options jsCodeLocation];
+}
+
+- (NSString *)keyFromURL:(NSURL *)url {
+  return [url absoluteString];
+}
+
+- (void)initBridgeWithOptions:(id<RNKiwiOptions>)options {
+  NSURL *url = [self resolveBundleURL:options];
+  NSString *key = [self keyFromURL:url];
+  
+  if (!_bridges[key]) {
+    _bridges[key] = [[RCTBridge alloc] initWithBundleURL:url moduleProvider:nil launchOptions:nil];
+  }  
+}
+
+- (RCTBridge *)bridgeForOptions:(id<RNKiwiOptions>)options {
+  NSString *key = [self keyFromURL:[self resolveBundleURL:options]];
+  return _bridges[key];
+}
+
+@end

--- a/ios/RNKiwiMobile/RNKiwiViewController.m
+++ b/ios/RNKiwiMobile/RNKiwiViewController.m
@@ -1,5 +1,6 @@
 #import "RNKiwiViewController.h"
 #import "RNKiwiOptions.h"
+#import "RNKiwiSharedBridge.h"
 
 #import <RNNavigator/RNNavigationModule.h>
 #import <RNLogging/RNLoggingModule.h>
@@ -25,7 +26,10 @@
   self = [super init];
   if (self) {
     _options = options;
+    
     [self setupReactWrappersWithObject:self];
+    
+    [[RNKiwiSharedBridge sharedInstance] initBridgeWithOptions:options];
   }
   
   return self;
@@ -41,14 +45,9 @@
 #pragma mark - View lifecycle
 
 - (void)loadView {
-  NSURL *bundleUrl = [_options respondsToSelector:@selector(jsCodeLocation)]
-    ? [_options jsCodeLocation]
-    : [[NSBundle bundleForClass:[self class]] URLForResource:@"hotels" withExtension:@"jsbundle"];
-  
-  self.view = [[RCTRootView alloc] initWithBundleURL:bundleUrl
-                                          moduleName:[_options moduleName]
-                                   initialProperties:[_options initialProperties]
-                                       launchOptions:nil];
+  self.view = [[RCTRootView alloc] initWithBridge:[[RNKiwiSharedBridge sharedInstance] bridgeForOptions:_options]
+                                       moduleName:[_options moduleName]
+                                initialProperties:[_options initialProperties]];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/ios/RNNativePlayground/ViewController.m
+++ b/ios/RNNativePlayground/ViewController.m
@@ -7,6 +7,21 @@
 
 @implementation ViewController
 
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super initWithCoder:coder];
+  if (self) {
+    /**
+     * In order to create bridge upfront, either create an instance of RNKiwiViewController
+     * ahead of time (here) and store as an instance property, or call this method instead.
+     *
+     * RNKiwiViewController does exactly the same thing for you behind the scenes if you use
+     * the former approach.
+     */
+    [[RNKiwiSharedBridge sharedInstance] initBridgeWithOptions:self];
+  }
+  return self;
+}
+
 - (IBAction)showHotelsView:(id)sender {
   RNKiwiViewController *vc = [[RNKiwiViewController alloc] initWithOptions:self];
   [vc setCurrencyFormatter:self];
@@ -29,6 +44,10 @@
 
 - (NSString *)moduleName {
   return @"KiwiHotels";
+}
+
+- (NSURL *)jsCodeLocation {
+  return RNKiwiConstants.hotelsBundle;
 }
 
 # pragma mark - RNKiwiCurrencyManager

--- a/ios/reactNativeApp.xcodeproj/project.pbxproj
+++ b/ios/reactNativeApp.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		2711986A20B1F7E300C6292B /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 929CCF0BD6A142DEAB8DA917 /* Octicons.ttf */; };
 		2711986B20B1F7E300C6292B /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6603DB7CD9F34D7AB1AD5B21 /* SimpleLineIcons.ttf */; };
 		2711986C20B1F7E300C6292B /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 46C66C53E2B841209A9370D0 /* Zocial.ttf */; };
+		2711986F20B2A0C100C6292B /* RNKiwiSharedBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 2711986D20B2A0C100C6292B /* RNKiwiSharedBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2711987020B2A0C100C6292B /* RNKiwiSharedBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 2711986E20B2A0C100C6292B /* RNKiwiSharedBridge.m */; };
 		27E931B420AD96790053AE19 /* RNKiwiMobile.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E931B220AD96790053AE19 /* RNKiwiMobile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27E931C020AD987C0053AE19 /* RNKiwiViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E931BE20AD987C0053AE19 /* RNKiwiViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27E931C120AD987C0053AE19 /* RNKiwiViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 27E931BF20AD987C0053AE19 /* RNKiwiViewController.m */; };
@@ -47,6 +49,8 @@
 		27E931E820ADA06C0053AE19 /* RNKiwiMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27E931B020AD96780053AE19 /* RNKiwiMobile.framework */; };
 		37478C9C708E472FBA98598C /* Roboto-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 21C03BEA6DA8479DBFFA62F0 /* Roboto-Regular.ttf */; };
 		3B029E80AD3948E19D4E6814 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F477A1D455304A4EA37DF899 /* MaterialIcons.ttf */; };
+		686E004B20B2E1360013512F /* RNKiwiConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 686E004A20B2E1360013512F /* RNKiwiConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		686E005120B2E24B0013512F /* RNKiwiConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 686E005020B2E24B0013512F /* RNKiwiConstants.m */; };
 		7EEEE5BA4A6944DCBDECD4C3 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 929CCF0BD6A142DEAB8DA917 /* Octicons.ttf */; };
 		9166DECF75BC4B9699DA0CBA /* SFProText-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 146DD9454CFB4E00BB34FBAA /* SFProText-Semibold.ttf */; };
 		A33D4A1D5C6845B3B939C9F8 /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 38EC9C92B1414019B0EAF6AF /* Foundation.ttf */; };
@@ -84,6 +88,8 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = reactNativeApp/main.m; sourceTree = "<group>"; };
 		146DD9454CFB4E00BB34FBAA /* SFProText-Semibold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "SFProText-Semibold.ttf"; path = "../assets/fonts/SFProText-Semibold.ttf"; sourceTree = "<group>"; };
 		21C03BEA6DA8479DBFFA62F0 /* Roboto-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-Regular.ttf"; path = "../assets/fonts/Roboto-Regular.ttf"; sourceTree = "<group>"; };
+		2711986D20B2A0C100C6292B /* RNKiwiSharedBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNKiwiSharedBridge.h; sourceTree = "<group>"; };
+		2711986E20B2A0C100C6292B /* RNKiwiSharedBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNKiwiSharedBridge.m; sourceTree = "<group>"; };
 		27E931B020AD96780053AE19 /* RNKiwiMobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RNKiwiMobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		27E931B220AD96790053AE19 /* RNKiwiMobile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNKiwiMobile.h; sourceTree = "<group>"; };
 		27E931B320AD96790053AE19 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -110,6 +116,8 @@
 		5377C27743964C6D8EF1FA05 /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 		645A06359A464CB0B63845A2 /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialCommunityIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
 		6603DB7CD9F34D7AB1AD5B21 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
+		686E004A20B2E1360013512F /* RNKiwiConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNKiwiConstants.h; sourceTree = "<group>"; };
+		686E005020B2E24B0013512F /* RNKiwiConstants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNKiwiConstants.m; sourceTree = "<group>"; };
 		68A42BBB8E1C6CD26053AC72 /* Pods-RNPlayground.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNPlayground.release.xcconfig"; path = "Pods/Target Support Files/Pods-RNPlayground/Pods-RNPlayground.release.xcconfig"; sourceTree = "<group>"; };
 		7362EE36714587FAF8D16632 /* Pods-RNKiwiMobile.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNKiwiMobile.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNKiwiMobile/Pods-RNKiwiMobile.debug.xcconfig"; sourceTree = "<group>"; };
 		83DEB0A076A11B421C735EE9 /* Pods-RNPlayground.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNPlayground.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNPlayground/Pods-RNPlayground.debug.xcconfig"; sourceTree = "<group>"; };
@@ -186,6 +194,10 @@
 			isa = PBXGroup;
 			children = (
 				27E931B220AD96790053AE19 /* RNKiwiMobile.h */,
+				686E004A20B2E1360013512F /* RNKiwiConstants.h */,
+				686E005020B2E24B0013512F /* RNKiwiConstants.m */,
+				2711986D20B2A0C100C6292B /* RNKiwiSharedBridge.h */,
+				2711986E20B2A0C100C6292B /* RNKiwiSharedBridge.m */,
 				27E931BE20AD987C0053AE19 /* RNKiwiViewController.h */,
 				27E931BF20AD987C0053AE19 /* RNKiwiViewController.m */,
 				27E931C820AD9AE90053AE19 /* RNKiwiOptions.h */,
@@ -284,6 +296,8 @@
 				27E931C720AD9A620053AE19 /* RNKiwiTranslationProvider.h in Headers */,
 				27E931C320AD9A2A0053AE19 /* RNKiwiViewControllerFlowDelegate.h in Headers */,
 				27E931C520AD9A4B0053AE19 /* RNKiwiCurrencyManager.h in Headers */,
+				2711986F20B2A0C100C6292B /* RNKiwiSharedBridge.h in Headers */,
+				686E004B20B2E1360013512F /* RNKiwiConstants.h in Headers */,
 				27E931B420AD96790053AE19 /* RNKiwiMobile.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -635,6 +649,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				27E931C120AD987C0053AE19 /* RNKiwiViewController.m in Sources */,
+				2711987020B2A0C100C6292B /* RNKiwiSharedBridge.m in Sources */,
+				686E005120B2E24B0013512F /* RNKiwiConstants.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This pull request targets my `work in progress` branch (that is subject to another PR). Until it gets merged to master, this pull request should not be merged.

==

This pull request implements shared bridge to improve startup of our iOS applications. It introduces singleton class, called `RNKiwiSharedBridge` that holds all the bridges created for bundle URLs. 

Since we haven't settled yet whether to go with multiple bundles (and bridges) or single bundle (and multiple components), this PR supports both use cases. 

I believe that even if we settle on a single bundle, the current implementation that uses NSDictionary is still reasonable given that the method signature is `bridgeForBundleURL` and assumes we accept returning multiple bridges.

Now, how to load bridge upfront to result from cache benefits - to do so, you have two options, depending on your preferences:

1) Call `[[RNKiwiSharedBridge] sharedInstance] initBridgeWithOptions:options]` where options are `RNKiwiOptions`, same used for `RNKiwiViewController`

2) Init an instance of `RNKiwiViewController` upfront, in constructor of its parent view controller, ahead of time. RNKiwiViewController automatically inits the bridge when it gets created and so, if you do it upfront, you basically mimic the former point.