### PR TITLE
Fix Flow 'StylePropType'

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -29,7 +29,14 @@
 [include]
 
 [untyped]
-<PROJECT_ROOT>/node_modules/react-native/Libraries/.+
+; Be careful - do not add 'StyleSheet' here
+<PROJECT_ROOT>/node_modules/react-native/Libraries/Animated/.+
+<PROJECT_ROOT>/node_modules/react-native/Libraries/Components/.+
+<PROJECT_ROOT>/node_modules/react-native/Libraries/Experimental/.+
+<PROJECT_ROOT>/node_modules/react-native/Libraries/Image/.+
+<PROJECT_ROOT>/node_modules/react-native/Libraries/Lists/.+
+<PROJECT_ROOT>/node_modules/react-native/Libraries/ReactNative/.+
+<PROJECT_ROOT>/node_modules/react-native/Libraries/Utilities/.+
 <PROJECT_ROOT>/node_modules/graphql/.+
 
 [libs]
@@ -69,7 +76,7 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowRelayIssue: https://github.com/facebook/rel
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError: .+
 
 [strict]
-nonstrict-import
+;nonstrict-import
 unclear-type
 unsafe-getters-setters
 ;untyped-import

--- a/app/shared/index.js
+++ b/app/shared/index.js
@@ -102,4 +102,8 @@ export type {
   PanResponderEvent,
 } from './types/Events';
 
-export type { StylePropType } from './types/Styles';
+export type {
+  StylePropType,
+  StyleObjectType,
+  PlatformStyleObjectType,
+} from './types/Styles';

--- a/app/shared/src/PlatformStyleSheet.js
+++ b/app/shared/src/PlatformStyleSheet.js
@@ -2,7 +2,7 @@
 
 import { StyleSheet, Platform } from 'react-native'; // eslint-disable-line no-restricted-imports
 
-import type { StylePropType } from '../index';
+import type { StyleObjectType, PlatformStyleObjectType } from '../index';
 
 /**
  * This StyleSheet allows to define platform differences easily:
@@ -24,7 +24,7 @@ export default {
   absoluteFillObject: StyleSheet.absoluteFillObject,
   flatten: StyleSheet.flatten,
 
-  create(styles: StylePropType): StylePropType {
+  create(styles: PlatformStyleObjectType): StyleObjectType {
     const platformStyles = {};
     Object.keys(styles).forEach(name => {
       let { ios, android, ...style } = { ...styles[name] };

--- a/app/shared/types/Styles.js
+++ b/app/shared/types/Styles.js
@@ -4,6 +4,23 @@
  * Styles are only reexported here to avoid importing internal RN libraries
  * everywhere (types are not exported directly).
  */
-import type { StyleProp as NativeStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-export type StylePropType = NativeStyleProp;
+import {
+  type ____DangerouslyImpreciseStyleProp_Internal,
+  type DangerouslyImpreciseStyle,
+} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+
+export type StyleObjectType = {
+  +[key: string]: $Shape<DangerouslyImpreciseStyle>,
+};
+
+export type PlatformStyleObjectType = {
+  +[key: string]: $Shape<
+    DangerouslyImpreciseStyle & {
+      android: DangerouslyImpreciseStyle,
+      ios: DangerouslyImpreciseStyle,
+    },
+  >,
+};
+
+export type StylePropType = ____DangerouslyImpreciseStyleProp_Internal;


### PR DESCRIPTION
It returned 'any' because of changed Relay internal structure. Don't be
scared by the weird names - I didn't find a better way how to do it. The
 good thing is that it will handle much more. For example it will not
 allow you to do this because it's invalid:

```
{
  fontWeight: 500,
}
```