### PR TITLE
Localization: Make translation promise cancellable

### DIFF
--- a/packages/localization/src/CancellableTranslation.js
+++ b/packages/localization/src/CancellableTranslation.js
@@ -1,0 +1,29 @@
+// @flow
+
+import { NativeModules } from 'react-native';
+
+export type TranslationPromise = {|
+  cancel: () => void,
+  promise: Promise<string>,
+|};
+
+export function cancellableTranslation(nativeKey: string): TranslationPromise {
+  let resolve;
+  let reject;
+
+  const promise = new Promise((originalResolve, originalReject) => {
+    resolve = originalResolve;
+    reject = originalReject;
+  });
+
+  NativeModules.RNTranslationManager.translateAsync(nativeKey)
+    .then(resolve)
+    .then(reject);
+
+  return {
+    promise,
+    cancel: () => {
+      reject('cancelled');
+    },
+  };
+}

--- a/packages/localization/src/__tests__/Translation.test.js
+++ b/packages/localization/src/__tests__/Translation.test.js
@@ -6,6 +6,8 @@ import renderer from 'react-test-renderer';
 
 import Translation from '../Translation';
 
+const CancellableTranslation = require('../CancellableTranslation');
+
 let Component;
 beforeEach(() => {
   Component = new Translation({
@@ -82,4 +84,21 @@ it('works with pass through translations and text transformations', () => {
     textTransform: 'uppercase',
   });
   expect(Component.render()).toMatchSnapshot();
+});
+
+it('does not call set state if promise is rejected', async () => {
+  let originalFunction = CancellableTranslation.cancellableTranslation;
+  // $FlowExpectedError: Intentionally overwriting function to test outcome
+  CancellableTranslation.cancellableTranslation = jest.fn(() => ({
+    promise: new Promise((resolve, reject) => {
+      reject();
+    }),
+  }));
+
+  jest.spyOn(Component, 'setState');
+  await Component.setTranslatedString();
+
+  expect(Component.setState).not.toHaveBeenCalled();
+  // $FlowExpectedError: Intentionally resetting function
+  CancellableTranslation.cancellableTranslation = originalFunction;
 });


### PR DESCRIPTION
Sometimes we get warning, can't call set state on unmounted component.
This happens when we leave a screen before all translations promises has resolved.

Making the promise cancellable should remove this warning.