### PR TITLE
MMB: Add other type of menu item

### DIFF
--- a/app/MMB/src/scenes/passenger/menu/MenuGroup.js
+++ b/app/MMB/src/scenes/passenger/menu/MenuGroup.js
@@ -1,0 +1,62 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { SimpleCard, StyleSheet } from '@kiwicom/mobile-shared';
+
+import { SeparatorFullWidth } from '../../../components/Separators';
+
+type Props = {|
+  children: React.Node,
+|};
+
+/**
+ * This component wraps <MenuItem/> and adds group title and visual separators.
+ * It is basically a copy of /components/MenuGroup, but it has a margin on both sides of the separator
+ * Example:
+ *
+ * .------------------------------.
+ * |                              |
+ * |  Title 1                     |
+ * |                              |
+ * |  --------------------------  |
+ * |                              |
+ * |  Title 2                     |
+ * |                              |
+ * `------------------------------`
+ */
+export default function MenuGroup(props: Props) {
+  let separator = null;
+  const children = Array.isArray(props.children)
+    ? props.children
+    : [props.children];
+
+  const groupChildren = children.map((child, index) => {
+    const wrappedChild = (
+      <React.Fragment key={index}>
+        {separator}
+        <View>{child}</View>
+      </React.Fragment>
+    );
+
+    separator = (
+      <View style={styles.separator}>
+        <SeparatorFullWidth />
+      </View>
+    );
+    return wrappedChild;
+  });
+
+  return <SimpleCard style={styles.card}>{groupChildren}</SimpleCard>;
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 0,
+  },
+  separator: {
+    ios: {
+      paddingHorizontal: 15,
+    },
+  },
+});

--- a/app/MMB/src/scenes/passenger/menu/MenuItem.js
+++ b/app/MMB/src/scenes/passenger/menu/MenuItem.js
@@ -1,0 +1,57 @@
+// @flow
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { Color, StyleSheet, Text } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
+
+type Props = {|
+  title: React.Element<typeof Translation>,
+  description: React.Element<typeof Translation>,
+|};
+
+/**
+ * This is basically a copy of /components/MenuItem
+ * But it has a light title instead of bold
+ * Example:
+ *
+ * .------------------------------.
+ * |                              |
+ * |  IC    Light Title           |
+ * |  ON    Description           |
+ * |                              |
+ * `------------------------------`
+ *
+ */
+export default function MenuItem(props: Props) {
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.middleWrapper}>
+        <Text style={styles.title}>{props.title}</Text>
+        {props.description}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flexDirection: 'row',
+    padding: 15,
+    android: {
+      backgroundColor: Color.white,
+      borderStartWidth: 5,
+      borderStartColor: Color.white,
+    },
+    ios: {
+      backgroundColor: Color.white,
+    },
+  },
+  middleWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  title: {
+    color: Color.textLight,
+  },
+});

--- a/app/MMB/src/scenes/passenger/menu/TitledMenuGroup.js
+++ b/app/MMB/src/scenes/passenger/menu/TitledMenuGroup.js
@@ -1,0 +1,32 @@
+// @flow
+
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { Translation } from '@kiwicom/mobile-localization';
+
+import MenuGroup from './MenuGroup';
+import MenuGroupTitle from '../../../components/menu/MenuGroupTitle';
+
+type Props = {|
+  title: React.Element<typeof Translation>,
+  children: React.Node,
+|};
+
+// This is basically a copy of /components/TitledMenuGroup
+// But it needs a different type of separator, so it uses ad different MenuGroup to wrap its children
+export default function TitledMenuGroup({ title, children }: Props) {
+  let newChildren = Array.isArray(children) ? children : [children];
+
+  if (Platform.OS === 'android') {
+    // we have to copy every children in order to prepend group title for Android
+    newChildren = [<MenuGroupTitle key="android-ftw" title={title} />];
+    React.Children.forEach(children, child => newChildren.push(child));
+  }
+
+  return (
+    <React.Fragment>
+      {Platform.OS === 'ios' && <MenuGroupTitle title={title} />}
+      <MenuGroup>{newChildren}</MenuGroup>
+    </React.Fragment>
+  );
+}

--- a/app/MMB/src/scenes/passenger/menu/__tests__/TitledMenuGroup.test.js
+++ b/app/MMB/src/scenes/passenger/menu/__tests__/TitledMenuGroup.test.js
@@ -1,0 +1,27 @@
+// @flow
+
+import * as React from 'react';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
+import { Translation } from '@kiwicom/mobile-localization';
+
+import TitledMenuGroup from '../TitledMenuGroup';
+import MenuItem from '../MenuItem';
+
+describe('TitledMenuGroup', () => {
+  it('renders', () => {
+    PlaygroundRenderer.render(
+      <TitledMenuGroup title={<Translation passThrough="GroupTitle!" />}>
+        <MenuItem
+          title={<Translation passThrough="Title!" />}
+          description={<Translation passThrough="Description!" />}
+        />
+        <MenuItem
+          title={<Translation passThrough="Title!" />}
+          description={<Translation passThrough="Description!" />}
+        />
+      </TitledMenuGroup>,
+      false,
+      'PassengerTitledMenuGroup',
+    );
+  });
+});

--- a/app/MMB/src/scenes/passenger/menu/__tests__/__snapshots__/TitledMenuGroup.test.js.snap
+++ b/app/MMB/src/scenes/passenger/menu/__tests__/__snapshots__/TitledMenuGroup.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TitledMenuGroup renders 1`] = `
+<UNDEFINED>
+  <MenuGroupTitle
+    title={
+      <Translation
+        passThrough="GroupTitle!"
+      />
+    }
+  />
+  <MenuGroup>
+    <MenuItem
+      description={
+        <Translation
+          passThrough="Description!"
+        />
+      }
+      title={
+        <Translation
+          passThrough="Title!"
+        />
+      }
+    />
+    <MenuItem
+      description={
+        <Translation
+          passThrough="Description!"
+        />
+      }
+      title={
+        <Translation
+          passThrough="Title!"
+        />
+      }
+    />
+  </MenuGroup>
+</UNDEFINED>
+`;

--- a/packages/playground/src/PlaygroundImports.js
+++ b/packages/playground/src/PlaygroundImports.js
@@ -11,6 +11,7 @@ import '../../../app/hotels/src/allHotels/searchForm/locationPicker/__tests__/Su
 import '../../../app/hotels/src/allHotels/searchForm/locationPicker/__tests__/RecentSearches.test.js';
 import '../../../app/hotels/src/allHotels/__tests__/LoadMoreButton.test.js';
 import '../../../app/MMB/src/scenes/passenger/visa/__tests__/VisaRequired.test.js';
+import '../../../app/MMB/src/scenes/passenger/menu/__tests__/TitledMenuGroup.test.js';
 import '../../../app/MMB/src/scenes/passenger/__tests__/Passenger.test.js';
 import '../../../app/MMB/src/components/alert/__tests__/Alert.test.js';
 import '../../../packages/shared/src/popup/__tests__/ButtonPopupPlayground.test.js';


### PR DESCRIPTION
These type of menu items are only (as far as I can see) used in the Passenger detail screen. It makes sense to keep them in the passenger folder.

If needed, we can extract them to the menu items folder later. 