### PR TITLE
Avoid appending calendar in device info locale

### DIFF
--- a/app/MMB/src/navigation/DetailShareButton.js
+++ b/app/MMB/src/navigation/DetailShareButton.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Share, Platform } from 'react-native';
-import { DateFormatter, GetDeviceLocale } from '@kiwicom/mobile-localization';
+import { DateFormatter, DeviceInfo } from '@kiwicom/mobile-localization';
 
 import BookingDetailContext from '../context/BookingDetailContext';
 import ShareButton from '../components/ShareButton';
@@ -14,7 +14,7 @@ type PropsWithContext = {|
 
 class DetailShareButton extends React.Component<PropsWithContext> {
   onPress = () => {
-    const lang = GetDeviceLocale().split('-')[0] || 'en';
+    const lang = DeviceInfo.getLanguage() || 'en';
     const message = `https://kiwi.com/share?date=${DateFormatter(
       this.props.arrivalTime,
     ).formatForMachine()}&city_id=${

--- a/app/MMB/src/scenes/tripServices/ParkingMenuItem.js
+++ b/app/MMB/src/scenes/tripServices/ParkingMenuItem.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Platform } from 'react-native';
 import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import { TextIcon } from '@kiwicom/mobile-shared';
-import { Translation, GetDeviceLocale } from '@kiwicom/mobile-localization';
+import { Translation, DeviceInfo } from '@kiwicom/mobile-localization';
 import { MenuItem } from '@kiwicom/mobile-navigation';
 import querystring from 'querystring';
 import idx from 'idx';
@@ -25,7 +25,7 @@ class ParkingMenuItem extends React.Component<Props> {
       whitelabelURL +
         (whitelabelURL.includes('?') ? '&' : '?') +
         querystring.stringify({
-          utm_source: 'kiwicom_' + GetDeviceLocale(), // this should be actually language only but the locale should be fine as well
+          utm_source: 'kiwicom_' + DeviceInfo.getLocaleDashed(), // this should be actually language only but the locale should be fine as well
           utm_medium: 'referral',
           utm_campaign: Platform.select({
             android: 'kiwi-android',

--- a/app/core/config/NativeModulesMocks/RNDeviceInfo.js
+++ b/app/core/config/NativeModulesMocks/RNDeviceInfo.js
@@ -3,5 +3,8 @@
 import { NativeModules } from 'react-native';
 
 NativeModules.RNDeviceInfo = {
-  Locale: 'en',
+  getLanguage: 'en',
+  getTerritory: 'US',
+  getLocaleUnderscored: 'en_US',
+  getLocaleDashed: 'en-US',
 };

--- a/ios/RNModules/RNDeviceInfo/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNModules/RNDeviceInfo/RNDeviceInfo/RNDeviceInfo.m
@@ -6,21 +6,35 @@
 RCT_EXPORT_MODULE();
 
 - (NSString *)currentLanguage {
-
-    NSString *localeIdentifier = [[NSLocale preferredLanguages] firstObject];
-
+    
+    NSString *localeIdentifier = [[NSLocale currentLocale] objectForKey: NSLocaleLanguageCode];
+    
     if (localeIdentifier == nil) {
-        NSLog(@"RNDeviceInfo: current locale is undefined");
+        NSLog(@"RNDeviceInfo: current language is undefined");
     }
+    
+    return localeIdentifier ?: @"en";
+}
 
-    return localeIdentifier ?: @"en-US";
+- (NSString *)currentTerritory {
+    
+    NSString *localeIdentifier = [[NSLocale currentLocale] objectForKey: NSLocaleCountryCode];
+    
+    if (localeIdentifier == nil) {
+        NSLog(@"RNDeviceInfo: current country code is undefined");
+    }
+    
+    return localeIdentifier ?: @"US";
 }
 
 - (NSDictionary *)constantsToExport {
 
     return @{
-        @"Locale": [self currentLanguage],
-    };
+             @"getLanguage": [self currentLanguage],
+             @"getTerritory": [self currentTerritory],
+             @"getLocaleUnderscored": [NSString stringWithFormat:@"%@_%@", [self currentLanguage], [self currentTerritory]],
+             @"getLocaleDashed": [NSString stringWithFormat:@"%@-%@", [self currentLanguage], [self currentTerritory]]
+            };
 }
 
 @end

--- a/packages/localization/index.js
+++ b/packages/localization/index.js
@@ -6,13 +6,13 @@ import Translation from './src/Translation';
 import TranslationFragment from './src/TranslationFragment';
 import DateFormatter from './src/DateFormatter';
 import DateUtils from './src/DateUtils';
-import GetDeviceLocale from './src/GetDeviceLocale';
+import DeviceInfo from './src/GetDeviceLocale';
 
 export {
   TranslationFragment,
   DateFormatter,
   DateUtils,
-  GetDeviceLocale,
+  DeviceInfo,
   Translation,
 };
 

--- a/packages/localization/src/DateFormatter.js
+++ b/packages/localization/src/DateFormatter.js
@@ -1,12 +1,12 @@
 // @flow strict
 
-import getDeviceLocale from './GetDeviceLocale';
+import { getLocaleDashed } from './GetDeviceLocale';
 
 import 'intl'; // Polyfill because of Android
 import 'intl/locale-data/complete';
 
 // language prop passed from native code is not accessible at this point
-const DEVICE_LOCALE = getDeviceLocale();
+const DEVICE_LOCALE = getLocaleDashed();
 
 function date(date: Date) {
   return Intl.DateTimeFormat(DEVICE_LOCALE, {

--- a/packages/localization/src/GetDeviceLocale.js
+++ b/packages/localization/src/GetDeviceLocale.js
@@ -2,4 +2,21 @@
 
 import { NativeModules } from 'react-native';
 
-export default () => NativeModules.RNDeviceInfo.Locale;
+const {
+  getLanguage: nativeGetLanguage,
+  getTerritory: nativeGetTerritory,
+  getLocaleUnderscored: nativeGetLocaleUnderscored,
+  getLocaleDashed: nativeGetLocaleDashed,
+} = NativeModules.RNDeviceInfo;
+
+export const getLanguage = () => nativeGetLanguage;
+export const getTerritory = () => nativeGetTerritory;
+export const getLocaleUnderscored = () => nativeGetLocaleUnderscored;
+export const getLocaleDashed = () => nativeGetLocaleDashed;
+
+export default {
+  getLanguage,
+  getTerritory,
+  getLocaleUnderscored,
+  getLocaleDashed,
+};

--- a/packages/relay/src/Environment.js
+++ b/packages/relay/src/Environment.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { GetDeviceLocale } from '@kiwicom/mobile-localization';
+import { DeviceInfo } from '@kiwicom/mobile-localization';
 import {
   Environment,
   Network,
@@ -53,7 +53,7 @@ export default function createEnvironment(accessToken: string = '') {
   const networkHeaders: Object = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
-    'Accept-Language': GetDeviceLocale().replace('-', '_'),
+    'Accept-Language': DeviceInfo.getLocaleUnderscored(),
   };
 
   if (accessToken) {

--- a/packages/shared/src/forms/datePicker/DatePicker.ios.js
+++ b/packages/shared/src/forms/datePicker/DatePicker.ios.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { DatePickerIOS } from 'react-native';
-import { Translation, GetDeviceLocale } from '@kiwicom/mobile-localization';
+import { Translation, DeviceInfo } from '@kiwicom/mobile-localization';
 
 import DatePickerButton from './DatePickerButton';
 import BarPopup from '../../popup/BarPopup';
@@ -63,7 +63,7 @@ export default class DatePicker extends React.Component<Props, State> {
             maximumDate={maxDate}
             date={this.state.date}
             onDateChange={this.onDateChange}
-            locale={GetDeviceLocale()}
+            locale={DeviceInfo.getLocaleDashed()}
             mode="date"
           />
         </BarPopup>


### PR DESCRIPTION
Related to: #738 

Currently `GetDeviceLocale` always will return object:
```
{
  Format: {
    Underscored: 'en_US',
    Dashed: 'en-US',
  },
  Language: 'en',
  Territory: 'US',
},
```
where `Format.Underscored` and `Format.Dashed` are a combination of `Language` and `Territory`. In that way we are able to avoid appending unnecessary `calendar=gregorian`.