### PR TITLE
Localization: DateFormatter allow timeZone adjustment

### DIFF
--- a/packages/localization/src/DateFormatter.js
+++ b/packages/localization/src/DateFormatter.js
@@ -8,26 +8,26 @@ import 'intl/locale-data/complete';
 // language prop passed from native code is not accessible at this point
 const DEVICE_LOCALE = getLocaleDashed();
 
-function date(date: Date) {
+function date(date: Date, timeZone: string) {
   return Intl.DateTimeFormat(DEVICE_LOCALE, {
-    timeZone: 'UTC', // this is very important!
+    timeZone,
     weekday: 'short',
     month: 'numeric',
     day: 'numeric',
   }).format(date);
 }
 
-function time(date: Date) {
+function time(date: Date, timeZone: string) {
   return Intl.DateTimeFormat(DEVICE_LOCALE, {
-    timeZone: 'UTC', // this is very important!
+    timeZone,
     hour: 'numeric',
     minute: 'numeric',
   }).format(date);
 }
 
-function birthday(date: Date) {
+function birthday(date: Date, timeZone: string) {
   return Intl.DateTimeFormat(DEVICE_LOCALE, {
-    timeZone: 'UTC', // this is very important!
+    timeZone,
     year: 'numeric',
     month: 'numeric',
     day: 'numeric',
@@ -48,11 +48,11 @@ function pad(number) {
  */
 function DateFormatter(rawDate: Date = new Date()) {
   return {
-    formatToDate: () => date(rawDate),
-    formatToTime: () => time(rawDate),
+    formatToDate: (timeZone: string = 'UTC') => date(rawDate, timeZone),
+    formatToTime: (timeZone: string = 'UTC') => time(rawDate, timeZone),
 
     // note: I am not sure about the naming - improve when needed
-    formatToBirthday: () => birthday(rawDate),
+    formatToBirthday: (timeZone: string = 'UTC') => birthday(rawDate, timeZone),
 
     /**
      * Always returns YYYY-MM-DD at this moment.

--- a/packages/localization/src/DateUtils.js
+++ b/packages/localization/src/DateUtils.js
@@ -67,4 +67,7 @@ DateUtils.isBeforeDate = (firstDate: Date, secondDate: Date): boolean => {
   );
 };
 
+DateUtils.getLocalTimeZone = () =>
+  Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export default DateUtils;


### PR DESCRIPTION
I think most our our current date problems is with formatting and timeZones, I will add a possibility to change time-zone for formatting. 

This makes sense to me, we can adjust for local timezone where needed, and our graphql returns timezone on locations, so we can also use that were it makes sense. 