### PR TITLE
chore: Update to react-navigation 2.x.x.

### DIFF
--- a/app/MMB/src/navigation/ListScreen.js
+++ b/app/MMB/src/navigation/ListScreen.js
@@ -11,7 +11,7 @@ export default function ListScreen() {
 }
 
 ListScreen.navigationOptions = () => ({
-  title: (
+  headerTitle: (
     <HeaderTitle>
       <Translation id="mmb.my_bookings.title.bookings" />
     </HeaderTitle>

--- a/app/MMB/src/navigation/NavigationStack.js
+++ b/app/MMB/src/navigation/NavigationStack.js
@@ -4,7 +4,6 @@ import {
   StackNavigator,
   StackNavigatorOptions,
 } from '@kiwicom/mobile-navigation';
-import { withMappedNavigationAndConfigProps as withMappedProps } from 'react-navigation-props-mapper';
 
 import DetailScreen, { MenuComponents } from './DetailScreen';
 import ListScreen from './ListScreen';
@@ -17,7 +16,7 @@ Object.entries(MenuComponents).forEach(
   // $FlowIssue: https://github.com/facebook/flow/issues/2221
   ([routeName, { screen, headerTitle }]) => {
     Screens[routeName] = {
-      screen: withMappedProps(screen),
+      screen,
       navigationOptions: {
         headerTitle,
       },
@@ -28,10 +27,10 @@ Object.entries(MenuComponents).forEach(
 const TravelDocumentStack = StackNavigator(
   {
     TravelDocumentScreen: {
-      screen: withMappedProps(FillTravelDocumentScreen),
+      screen: FillTravelDocumentScreen,
     },
     TravelDocumentModalScreen: {
-      screen: withMappedProps(TravelDocumentModalScreen),
+      screen: TravelDocumentModalScreen,
     },
   },
   {
@@ -44,10 +43,10 @@ const TravelDocumentStack = StackNavigator(
 const MainStack = StackNavigator(
   {
     ListScreen: {
-      screen: withMappedProps(ListScreen),
+      screen: ListScreen,
     },
     DetailScreen: {
-      screen: withMappedProps(DetailScreen),
+      screen: DetailScreen,
     },
     ...Screens,
   },
@@ -60,10 +59,10 @@ const MainStack = StackNavigator(
 export default StackNavigator(
   {
     MMBMainStack: {
-      screen: withMappedProps(MainStack),
+      screen: MainStack,
     },
     TravelDocumentScreen: {
-      screen: withMappedProps(TravelDocumentStack),
+      screen: TravelDocumentStack,
     },
   },
   {

--- a/app/MMB/src/navigation/NavigationStack.js
+++ b/app/MMB/src/navigation/NavigationStack.js
@@ -4,6 +4,7 @@ import {
   StackNavigator,
   StackNavigatorOptions,
 } from '@kiwicom/mobile-navigation';
+import { withMappedNavigationAndConfigProps as withMappedProps } from 'react-navigation-props-mapper';
 
 import DetailScreen, { MenuComponents } from './DetailScreen';
 import ListScreen from './ListScreen';
@@ -16,7 +17,7 @@ Object.entries(MenuComponents).forEach(
   // $FlowIssue: https://github.com/facebook/flow/issues/2221
   ([routeName, { screen, headerTitle }]) => {
     Screens[routeName] = {
-      screen,
+      screen: withMappedProps(screen),
       navigationOptions: {
         headerTitle,
       },
@@ -27,10 +28,10 @@ Object.entries(MenuComponents).forEach(
 const TravelDocumentStack = StackNavigator(
   {
     TravelDocumentScreen: {
-      screen: FillTravelDocumentScreen,
+      screen: withMappedProps(FillTravelDocumentScreen),
     },
     TravelDocumentModalScreen: {
-      screen: TravelDocumentModalScreen,
+      screen: withMappedProps(TravelDocumentModalScreen),
     },
   },
   {
@@ -43,10 +44,10 @@ const TravelDocumentStack = StackNavigator(
 const MainStack = StackNavigator(
   {
     ListScreen: {
-      screen: ListScreen,
+      screen: withMappedProps(ListScreen),
     },
     DetailScreen: {
-      screen: DetailScreen,
+      screen: withMappedProps(DetailScreen),
     },
     ...Screens,
   },

--- a/app/core/src/navigation/index.js
+++ b/app/core/src/navigation/index.js
@@ -8,7 +8,7 @@ import {
 import { Color } from '@kiwicom/mobile-shared';
 import { Translation } from '@kiwicom/mobile-localization';
 import ProfileScreen from '@kiwicom/mobile-profile';
-import { TabNavigator } from 'react-navigation';
+import { createBottomTabNavigator } from 'react-navigation';
 
 import HotelsStack from './HotelsStack';
 import MMBPackage from '../screens/MMBPackageWrapper';
@@ -41,7 +41,7 @@ const ProfileStack = StackNavigator(
   },
 );
 
-export default TabNavigator(
+export default createBottomTabNavigator(
   {
     Search: { screen: HotelsStack },
     Bookings: { screen: MMBPackage },

--- a/app/core/src/screens/MMBPackageWrapper.js
+++ b/app/core/src/screens/MMBPackageWrapper.js
@@ -21,6 +21,8 @@ export default class MMBPackageWrapper extends React.Component<
     token: '',
   };
 
+  willFocusSubscription: { remove: () => void };
+
   componentDidMount = () => {
     this.willFocusSubscription = this.props.navigation.addListener(
       'willFocus',

--- a/app/core/src/screens/MMBPackageWrapper.js
+++ b/app/core/src/screens/MMBPackageWrapper.js
@@ -21,29 +21,19 @@ export default class MMBPackageWrapper extends React.Component<
     token: '',
   };
 
-  static navigationOptions = ({
-    navigation,
-  }: {
-    navigation: NavigationType,
-  }) => {
-    return {
-      tabBarOnPress: ({
-        scene,
-        jumpToIndex,
-      }: {
-        scene: {| index: number |},
-        jumpToIndex: (index: number) => void,
-      }) => {
-        jumpToIndex(scene.index);
-        navigation.state.params.fetchToken();
+  componentDidMount = () => {
+    this.willFocusSubscription = this.props.navigation.addListener(
+      'willFocus',
+      () => {
+        this.fetchToken();
       },
-    };
+    );
+    this.fetchToken();
   };
 
-  componentDidMount = () => {
-    this.fetchToken();
-    this.props.navigation.setParams({ fetchToken: this.fetchToken });
-  };
+  componentWillUnmount() {
+    this.willFocusSubscription.remove();
+  }
 
   fetchToken = async () => {
     const token = await AsyncStorage.getItem('mobile:MMB-Token');

--- a/app/hotels/src/navigation/allHotels/GuestsModalScreen.js
+++ b/app/hotels/src/navigation/allHotels/GuestsModalScreen.js
@@ -142,7 +142,7 @@ export default class GuestsModalScreenWithContext extends React.Component<
           <Translation id="hotels_search.guests_modal.close" />
         </HeaderButton>
       ),
-      title: (
+      headerTitle: (
         <HeaderTitle>
           <Translation id="hotels_search.guests_modal.header" />
         </HeaderTitle>

--- a/app/hotels/src/navigation/allHotels/LocationPickerScreen.js
+++ b/app/hotels/src/navigation/allHotels/LocationPickerScreen.js
@@ -49,7 +49,7 @@ export default class LocationPickerScreen extends React.Component<Props> {
           </Text>
         </HeaderButton>
       ),
-      title: (
+      headerTitle: (
         <HeaderTitle>
           <Translation id="hotels_search.location_picker.header" />
         </HeaderTitle>

--- a/app/hotels/src/navigation/allHotels/__tests__/AllHotelsNavigationScreen.test.js
+++ b/app/hotels/src/navigation/allHotels/__tests__/AllHotelsNavigationScreen.test.js
@@ -15,6 +15,9 @@ const navigation = {
   state: {
     params: {},
   },
+  addListener: jest.fn(() => ({
+    remove: jest.fn(),
+  })),
 };
 
 const getNavigationOptions = (lastNavigationMode?: string) => {

--- a/app/hotels/src/navigation/allHotels/__tests__/GuestsModalScreen.test.js
+++ b/app/hotels/src/navigation/allHotels/__tests__/GuestsModalScreen.test.js
@@ -16,6 +16,9 @@ const navigation = {
   state: {
     params: {},
   },
+  addListener: jest.fn(() => ({
+    remove: jest.fn(),
+  })),
 };
 
 const shallowRenderGuestsPopup = (searchChange: Function) => {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ YellowBox.ignoreWarnings([
   'Warning: isMounted(...) is deprecated in plain JavaScript React classes.',
   'Module R', // ... requires main queue setup since it overrides ...
   'Class RCTCxxModule was not exported. Did you forget to use RCT_EXPORT_MODULE()?', // https://github.com/facebook/react-native/issues/18201
+  // TODO this a warning from react-navigation, see: https://reactnavigation.org/docs/en/common-mistakes.html
+  // This happens in our app because the package-stack architecture we have for native apps
+  'You should only render one navigator',
 ]);
 
 import App from './app/App';

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@kiwicom/mobile-localization": "^0",
     "@kiwicom/mobile-shared": "^0",
-    "react-navigation": "^1.5.11",
+    "react-navigation": "^2.6.2",
     "react-navigation-props-mapper": "^0.1.2"
   }
 }

--- a/packages/navigation/types/Navigation.js
+++ b/packages/navigation/types/Navigation.js
@@ -55,6 +55,12 @@ export type RouteNames =
   | HomepageStackNavigatorRouteNames
   | PlaygroundNavigationRouteNames;
 
+export type NavigationListener = (
+  key: 'willBlur' | 'willFocus' | 'didFocus' | 'didBlur',
+  // See payload https://reactnavigation.org/docs/en/navigation-prop.html#addlistener-subscribe-to-updates-to-navigation-lifecycle
+  callback: (payload: Object) => void,
+) => { remove: () => void };
+
 /**
  * @see https://reactnavigation.org/docs/navigators/navigation-prop
  */
@@ -69,4 +75,5 @@ export type Navigation = {
   },
   setParams: (newParameters: NavigationStateParameters) => void,
   goBack: (key?: string | null) => void,
+  addListener: NavigationListener,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,6 +2131,13 @@ create-react-class@^15.6.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2836,6 +2843,18 @@ fbjs-scripts@^0.8.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -3223,6 +3242,10 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+
 gulp-util@^3.0.4:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
@@ -3384,6 +3407,10 @@ hoek@4.x.x:
 hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+
+hoist-non-react-statics@^2.5.0:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -5547,6 +5574,13 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -5613,9 +5647,9 @@ react-is@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
 
-react-lifecycles-compat@^1.0.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-1.1.4.tgz#fc005c72849b7ed364de20a0f64ff58ebdc2009a"
+react-lifecycles-compat@^3, react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
 react-native-animatable@^1.2.4:
   version "1.2.4"
@@ -5700,6 +5734,12 @@ react-native-safe-area-view@^0.7.0:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
+react-native-safe-area-view@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.8.0.tgz#22d78cb8e8658d04a10cd53c1546e0bc86cb7aea"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
 react-native-share@^1.0.27:
   version "1.0.27"
   resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-1.0.27.tgz#1861afe0d1256bde95d19520ca5d5c3cd348ffad"
@@ -5717,11 +5757,17 @@ react-native-swiper@^1.5.13:
   dependencies:
     prop-types "^15.5.10"
 
-"react-native-tab-view@github:react-navigation/react-native-tab-view":
-  version "0.0.74"
-  resolved "https://codeload.github.com/react-navigation/react-native-tab-view/tar.gz/36ebd834d78b841fc19778c966465d02fd1213bb"
+react-native-tab-view@^0.0.77:
+  version "0.0.77"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz#11ceb8e7c23100d07e628dc151b57797524d00d4"
   dependencies:
     prop-types "^15.6.0"
+
+react-native-tab-view@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-1.0.2.tgz#66e0bc6d38a227ed2b212e3a256b7902f6ce02ed"
+  dependencies:
+    prop-types "^15.6.1"
 
 react-native-tooltips@^0.0.6:
   version "0.0.6"
@@ -5799,24 +5845,48 @@ react-native@0.55.4:
     xmldoc "^0.4.0"
     yargs "^9.0.0"
 
+react-navigation-deprecated-tab-navigator@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-navigation-deprecated-tab-navigator/-/react-navigation-deprecated-tab-navigator-1.3.0.tgz#015dcae1e977b984ca7e99245261c15439026bb7"
+  dependencies:
+    react-native-tab-view "^0.0.77"
+
+react-navigation-drawer@0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/react-navigation-drawer/-/react-navigation-drawer-0.4.3.tgz#c04c94e2429b7e724801af05bd0a93a79cb27f71"
+  dependencies:
+    react-native-drawer-layout-polyfill "^1.3.2"
+
 react-navigation-props-mapper@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/react-navigation-props-mapper/-/react-navigation-props-mapper-0.1.3.tgz#829c85159e3125f7d32f2282c6429c64c8d4f1cb"
   dependencies:
     hoist-non-react-statics "^2.2.1"
 
-react-navigation@^1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.5.11.tgz#fba6ab45d7b9987c1763a5aaac53b4f6d62b7f5c"
+react-navigation-tabs@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/react-navigation-tabs/-/react-navigation-tabs-0.5.1.tgz#ed33bce3a3e21b92646700de25bd94b8fc570371"
+  dependencies:
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+    react-native-safe-area-view "^0.7.0"
+    react-native-tab-view "^1.0.0"
+
+react-navigation@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-2.6.2.tgz#a8fdb69c5876698f7e58c5a3962a78ba24bb2058"
   dependencies:
     clamp "^1.0.1"
+    create-react-context "^0.2.1"
     hoist-non-react-statics "^2.2.0"
     path-to-regexp "^1.7.0"
-    prop-types "^15.5.10"
-    react-lifecycles-compat "^1.0.2"
-    react-native-drawer-layout-polyfill "^1.3.2"
-    react-native-safe-area-view "^0.7.0"
-    react-native-tab-view "github:react-navigation/react-native-tab-view"
+    query-string "^6.1.0"
+    react-lifecycles-compat "^3"
+    react-native-safe-area-view "^0.8.0"
+    react-navigation-deprecated-tab-navigator "1.3.0"
+    react-navigation-drawer "0.4.3"
+    react-navigation-tabs "0.5.1"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -6659,6 +6729,10 @@ stream-counter@~0.2.0:
   dependencies:
     readable-stream "~1.1.8"
 
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -6939,6 +7013,10 @@ type-is@~1.6.6:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+ua-parser-js@^0.7.18:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Closes #861.

Got two warnings (one ignored):

- https://reactnavigation.org/docs/en/common-mistakes.html <-- Ignored due our architecture with package and stack (to include in native app). We can review it later

- ~`react-navigation-props-mapper` gives a warning if used in stateless components (I removed it from MMB for now <-- I do not see is used there?). Question, can we remove it entirely? I do not see a huge benefit on using this dependency (we are using `navigate.state.params` in different places anyway). CC @tbergq~ Solved.