### PR TITLE
iOS: block swiping back on modally presented screen

### DIFF
--- a/app/MMB/src/scenes/travelDocument/menuItem/PassengerMenuItem.js
+++ b/app/MMB/src/scenes/travelDocument/menuItem/PassengerMenuItem.js
@@ -29,6 +29,7 @@ class PassengerMenuItem extends React.Component<Props> {
         idNumber: idx(this.props.data, _ => _.travelDocument.idNumber) || null,
         expiryDate:
           idx(this.props.data, _ => _.travelDocument.expiration) || null,
+        isModal: true,
       },
     });
   };

--- a/app/hotels/src/appRegistry/HotelsStandalonePackage.js
+++ b/app/hotels/src/appRegistry/HotelsStandalonePackage.js
@@ -20,10 +20,15 @@ type Props = {
   checkout?: string,
   onNavigationStateChange: () => void,
   onBackClicked: () => void,
+  onNavigator: (ref: React.ElementRef<*>) => void,
   dimensions: DimensionType,
 };
 
 class HotelsStandalonePackage extends React.Component<Props> {
+  navigatorRef = (ref: React.ElementRef<*>) => {
+    this.props.onNavigator(ref);
+  };
+
   renderInnerComponent = () => {
     const checkin = this.props.checkin ? new Date(this.props.checkin) : null;
     const checkout = this.props.checkout ? new Date(this.props.checkout) : null;
@@ -38,6 +43,7 @@ class HotelsStandalonePackage extends React.Component<Props> {
         screenProps={screenProps}
         onBackClicked={this.props.onBackClicked}
         onNavigationStateChange={this.props.onNavigationStateChange}
+        ref={this.navigatorRef}
       />
     );
   };

--- a/app/hotels/src/appRegistry/SingleHotelStandalonePackage.js
+++ b/app/hotels/src/appRegistry/SingleHotelStandalonePackage.js
@@ -21,10 +21,15 @@ type Props = {
   language: string,
   onNavigationStateChange: () => void,
   onBackClicked: () => void,
+  onNavigator: (ref: React.ElementRef<*>) => void,
   dimensions: DimensionType,
 };
 
 class SingleHotelStandAlonePackage extends React.Component<Props> {
+  navigatorRef = (ref: React.ElementRef<*>) => {
+    this.props.onNavigator(ref);
+  };
+
   renderInnerComponent = () => {
     const screenProps = {
       ...this.props,
@@ -39,6 +44,7 @@ class SingleHotelStandAlonePackage extends React.Component<Props> {
         screenProps={screenProps}
         onBackClicked={this.props.onBackClicked}
         onNavigationStateChange={this.props.onNavigationStateChange}
+        ref={this.navigatorRef}
       />
     );
   };

--- a/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
+++ b/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
@@ -81,6 +81,7 @@ export default class AllHotelsNavigationScreen extends React.Component<Props> {
       key: 'key-LocationPicker',
       params: {
         location,
+        isModal: true,
       },
     });
   };
@@ -89,6 +90,9 @@ export default class AllHotelsNavigationScreen extends React.Component<Props> {
     this.props.navigation.navigate({
       routeName: 'GuestsModal',
       key: 'key-GuestsModal',
+      params: {
+        isModal: true,
+      },
     });
   };
 

--- a/app/hotels/src/navigation/singleHotel/SingleHotelNavigationScreen.js
+++ b/app/hotels/src/navigation/singleHotel/SingleHotelNavigationScreen.js
@@ -74,6 +74,7 @@ class SingleHotelNavigationScreen extends React.Component<Props> {
         affiliateId: this.props.bookingComAffiliate,
         language: this.props.language,
         currency: this.props.currency,
+        isModal: true,
       },
     });
   };

--- a/packages/navigation/index.js
+++ b/packages/navigation/index.js
@@ -147,3 +147,4 @@ export const createTransparentHeaderStyle = (dim: DimensionType) => {
 
 export type { RouteNames as RouteNamesType } from './types/Navigation';
 export type { Navigation as NavigationType } from './types/Navigation';
+export type { Navigator as NavigatorType } from './types/Navigation';

--- a/packages/navigation/types/Navigation.js
+++ b/packages/navigation/types/Navigation.js
@@ -77,3 +77,24 @@ export type Navigation = {
   goBack: (key?: string | null) => void,
   addListener: NavigationListener,
 };
+
+type Routes = Array<{|
+  key: string,
+  index: number,
+  isTransitioning: boolean,
+  routeName: string,
+|}>;
+
+export type Navigator = {
+  state: {
+    nav: {
+      key: string,
+      index: number,
+      isTransitioning: boolean,
+      params?: {|
+        isModal: boolean,
+      |},
+      routes: Routes,
+    },
+  },
+};

--- a/packages/navigation/types/Navigation.js
+++ b/packages/navigation/types/Navigation.js
@@ -78,23 +78,23 @@ export type Navigation = {
   addListener: NavigationListener,
 };
 
-type Routes = Array<{|
-  key: string,
-  index: number,
-  isTransitioning: boolean,
-  routeName: string,
+type Routes = $ReadOnlyArray<{|
+  +key: string,
+  +index: number,
+  +isTransitioning: boolean,
+  +routeName: string,
 |}>;
 
-export type Navigator = {
-  state: {
-    nav: {
-      key: string,
-      index: number,
-      isTransitioning: boolean,
-      params?: {|
+export type Navigator = {|
+  +state: {|
+    +nav: {|
+      +key: string,
+      +index: number,
+      +isTransitioning: boolean,
+      +params?: {|
         isModal: boolean,
       |},
-      routes: Routes,
-    },
-  },
-};
+      +routes: Routes,
+    |},
+  |},
+|};

--- a/packages/shared/src/WithNativeNavigation.js
+++ b/packages/shared/src/WithNativeNavigation.js
@@ -9,9 +9,9 @@ type NavigationState = {|
 |};
 
 type InjectedProps = {|
-  onNavigationStateChange: () => void,
-  onBackClicked: () => void,
-  onNavigator: (ref: React.ElementRef<*>) => void,
+  +onNavigationStateChange: () => void,
+  +onBackClicked: () => void,
+  +onNavigator: (ref: React.ElementRef<*>) => void,
 |};
 
 function withNativeNavigation<Props: {}>(

--- a/packages/shared/src/WithNativeNavigation.js
+++ b/packages/shared/src/WithNativeNavigation.js
@@ -27,13 +27,13 @@ function withNativeNavigation<Props: {}>(
       this.currentIndex = 0;
     }
 
-    nestings = function nestings(nav) {
+    isCurrentRouteModal(nav) {
       const nestedNav =
         nav.routes && nav.index !== undefined && nav.routes[nav.index];
       if (!nestedNav) {
         return nav.params && nav.params.isModal;
       }
-      return nestings(nestedNav);
+      return this.isCurrentRouteModal(nestedNav);
     };
 
     onNavigationStateChange = (
@@ -42,7 +42,7 @@ function withNativeNavigation<Props: {}>(
     ) => {
       const nav = this.navigator.state.nav;
 
-      if (this.nestings(nav)) {
+      if (this.isCurrentRouteModal(nav)) {
         GestureController.disableGestures(moduleName);
       } else if (currentState.index === 0) {
         GestureController.enableGestures(moduleName);

--- a/packages/shared/src/WithNativeNavigation.js
+++ b/packages/shared/src/WithNativeNavigation.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { GestureController } from '@kiwicom/mobile-shared';
+import { type NavigatorType } from '@kiwicom/mobile-navigation';
 
 type NavigationState = {|
   index: number,
@@ -10,6 +11,7 @@ type NavigationState = {|
 type InjectedProps = {|
   onNavigationStateChange: () => void,
   onBackClicked: () => void,
+  onNavigator: (ref: React.ElementRef<*>) => void,
 |};
 
 function withNativeNavigation<Props: {}>(
@@ -18,16 +20,31 @@ function withNativeNavigation<Props: {}>(
 ): React.ComponentType<$Diff<Props, InjectedProps>> {
   return class WithNativeNavigation extends React.Component<*> {
     currentIndex: number;
+    navigator: NavigatorType;
 
     constructor(props) {
       super(props);
       this.currentIndex = 0;
     }
+
+    nestings = function nestings(nav) {
+      const nestedNav =
+        nav.routes && nav.index !== undefined && nav.routes[nav.index];
+      if (!nestedNav) {
+        return nav.params && nav.params.isModal;
+      }
+      return nestings(nestedNav);
+    };
+
     onNavigationStateChange = (
       previousState: NavigationState,
       currentState: NavigationState,
     ) => {
-      if (currentState.index === 0) {
+      const nav = this.navigator.state.nav;
+
+      if (this.nestings(nav)) {
+        GestureController.disableGestures(moduleName);
+      } else if (currentState.index === 0) {
         GestureController.enableGestures(moduleName);
         this.currentIndex = 0;
       } else if (currentState.index > 0) {
@@ -44,12 +61,17 @@ function withNativeNavigation<Props: {}>(
       return false;
     };
 
+    onNavigator = navigator => {
+      this.navigator = navigator;
+    };
+
     render() {
       return (
         <WrappedComponent
           onBackClicked={
             GestureController.isNativeGestureModule ? this.onBackClicked : null
           }
+          onNavigator={this.onNavigator}
           onNavigationStateChange={this.onNavigationStateChange}
           {...this.props}
         />


### PR DESCRIPTION
With that solution it's necessary to add `isModule: true` to `params` when declaring `modal` screen, eg:
```
    this.props.navigation.navigate({
      routeName: 'XYZ',
      key: 'key-XYZ',
      params: {
        isModal: true,
      },
    });
```