### PR TITLE
fix: Do not allow swipe back on iOS modals

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 app/core/config/flow-typed
 **/node_modules/**
 **/RNAndroidPlayground/**
+/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ buck-out/
 *.cer
 *.mobileprovision
 *.dSYM.zip
+
+# Jest
+/coverage

--- a/app/core/config/NativeModulesMocks/RNKiwiGestureController.js
+++ b/app/core/config/NativeModulesMocks/RNKiwiGestureController.js
@@ -5,4 +5,6 @@ import { NativeModules } from 'react-native';
 NativeModules.RNKiwiGestureController = {
   enableGestures: jest.fn((moduleName: string) => moduleName),
   disableGestures: jest.fn((moduleName: string) => moduleName),
+  closeModal: jest.fn(),
+  invokeDefaultBackButton: jest.fn(),
 };

--- a/packages/shared/src/__tests__/WithNativeNavigation.test.js
+++ b/packages/shared/src/__tests__/WithNativeNavigation.test.js
@@ -1,0 +1,124 @@
+// @flow
+
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import { GestureController } from '@kiwicom/mobile-shared';
+
+import WithNativeNavigation from '../WithNativeNavigation';
+
+type Props = {
+  onNavigationStateChange: () => void,
+  onBackClicked: () => void,
+};
+
+describe('WithNativeNavigation', () => {
+  const WrappedComponent = class TestComponent extends React.Component<Props> {
+    render() {
+      return null;
+    }
+  };
+
+  const TestKey = 'test-key';
+  const getComponent = () => {
+    const Component = WithNativeNavigation(WrappedComponent, TestKey);
+    return renderer.create(<Component />);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enables gestures if it was not enabled', () => {
+    const onNavigationStateChange = getComponent().getInstance()
+      .onNavigationStateChange;
+
+    const callEnable = () =>
+      onNavigationStateChange(
+        {},
+        {
+          routes: [
+            {
+              routes: [],
+            },
+          ],
+        },
+      );
+
+    callEnable();
+    expect(GestureController.enableGestures).toHaveBeenCalledTimes(1);
+
+    callEnable();
+    // Still 1 time because we do not call if it was the last call
+    expect(GestureController.enableGestures).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables gestures if it was not enabled 1', () => {
+    const onNavigationStateChange = getComponent().getInstance()
+      .onNavigationStateChange;
+
+    const callDisable = () =>
+      onNavigationStateChange(
+        {},
+        {
+          routes: [
+            {
+              routes: [{ index: 0 }, { index: 1 }],
+            },
+          ],
+        },
+      );
+
+    callDisable();
+    expect(GestureController.disableGestures).toHaveBeenCalledTimes(1);
+
+    callDisable();
+    // Still 1 time because we do not call if it was the last call
+    expect(GestureController.disableGestures).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables gestures if it was not enabled 2', () => {
+    const onNavigationStateChange = getComponent().getInstance()
+      .onNavigationStateChange;
+
+    onNavigationStateChange(
+      {},
+      {
+        routes: [
+          {
+            routes: [],
+          },
+          {
+            routes: [],
+          },
+        ],
+      },
+    );
+    expect(GestureController.disableGestures).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles the back button', () => {
+    const instance = getComponent().getInstance();
+    const onNavigationStateChange = instance.onNavigationStateChange;
+    const onBackClicked = instance.onBackClicked;
+
+    // Enabled first state
+    expect(onBackClicked()).toBe(true);
+    expect(GestureController.invokeDefaultBackButton).toHaveBeenCalledTimes(1);
+
+    GestureController.invokeDefaultBackButton.mockClear();
+
+    // Disabled it
+    onNavigationStateChange(
+      {},
+      {
+        routes: [
+          {
+            routes: [{ index: 0 }, { index: 1 }],
+          },
+        ],
+      },
+    );
+    expect(onBackClicked()).toBe(false);
+    expect(GestureController.invokeDefaultBackButton).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
Fixes #871.

- [x] Fix withNativeNavigation for modals
- [x] Write unit test for the whole withNativeNavigation