### PR TITLE
New types for react-navigation 2

### DIFF
--- a/app/MMB/src/components/MissingInformation.js
+++ b/app/MMB/src/components/MissingInformation.js
@@ -37,10 +37,7 @@ export class MissingInformation extends React.Component<PropsWithContext> {
   };
 
   fillInPassengerInfo = () => {
-    this.props.navigation.navigate({
-      routeName: 'TravelDocumentScreen',
-      key: 'key-TravelDocumentScreen',
-    });
+    this.props.navigation.navigate('TravelDocumentScreen');
   };
 
   render = () => {

--- a/app/MMB/src/scenes/FlightServices.js
+++ b/app/MMB/src/scenes/FlightServices.js
@@ -19,10 +19,7 @@ type Props = {|
 
 export default class FlightServices extends React.Component<Props> {
   navigate = (key: RouteNamesType) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-    });
+    this.props.navigation.navigate(key);
   };
 
   handleOpenBaggage = () => {

--- a/app/MMB/src/scenes/Other.js
+++ b/app/MMB/src/scenes/Other.js
@@ -21,10 +21,7 @@ type Props = {|
 
 export default class Other extends React.Component<Props> {
   navigate = (key: RouteNamesType) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-    });
+    this.props.navigation.navigate(key);
   };
 
   handleOpenInvoice = () => {

--- a/app/MMB/src/scenes/flightServices/FlightServicesMenuGroup.js
+++ b/app/MMB/src/scenes/flightServices/FlightServicesMenuGroup.js
@@ -83,12 +83,8 @@ export class FlightServicesMenuGroup extends React.Component<Props, State> {
   };
 
   navigate = (key: RouteNamesType) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-      params: {
-        bookingId: idx(this.props.bookedServices, _ => _.databaseId),
-      },
+    this.props.navigation.navigate(key, {
+      bookingId: idx(this.props.bookedServices, _ => _.databaseId),
     });
   };
 

--- a/app/MMB/src/scenes/help/index.js
+++ b/app/MMB/src/scenes/help/index.js
@@ -19,10 +19,7 @@ type Props = {|
 
 export default class Help extends React.Component<Props> {
   navigate = (key: RouteNamesType) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-    });
+    this.props.navigation.navigate(key);
   };
 
   handleOpenHelp = () => {

--- a/app/MMB/src/scenes/list/cityImage/CityImageContainer.js
+++ b/app/MMB/src/scenes/list/cityImage/CityImageContainer.js
@@ -51,10 +51,7 @@ class CityImageContainer extends React.Component<PropsWithContext> {
       departureTime: new Date(departureTime),
     });
 
-    this.props.navigation.navigate({
-      routeName: 'DetailScreen',
-      key: 'key-DetailScreen',
-    });
+    this.props.navigation.navigate('DetailScreen');
   };
 
   render = () => (

--- a/app/MMB/src/scenes/passenger/baggage/BaggageGroupButton.js
+++ b/app/MMB/src/scenes/passenger/baggage/BaggageGroupButton.js
@@ -13,10 +13,7 @@ type Props = {|
 
 class BaggageGroupButton extends React.Component<Props> {
   goToBaggage = () => {
-    this.props.navigation.navigate({
-      routeName: 'mmb.flight_services.checked_baggage',
-      key: 'key-mmb.flight_services.checked_baggage',
-    });
+    this.props.navigation.navigate('mmb.flight_services.checked_baggage');
   };
 
   render = () => (

--- a/app/MMB/src/scenes/tickets/ETicket.js
+++ b/app/MMB/src/scenes/tickets/ETicket.js
@@ -29,11 +29,7 @@ type Props = {|
 
 class ETicket extends React.Component<Props> {
   navigate = (key: RouteNamesType, params?: Object) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-      params,
-    });
+    this.props.navigation.navigate(key, params);
   };
 
   openDocument = () => {

--- a/app/MMB/src/scenes/tickets/boardingPasses/DownloadButton.js
+++ b/app/MMB/src/scenes/tickets/boardingPasses/DownloadButton.js
@@ -18,12 +18,8 @@ type Props = {|
 
 class DownloadButton extends React.Component<Props> {
   navigateToBoardingPass = () => {
-    this.props.navigation.navigate({
-      routeName: 'mmb.tickets.boarding_pass',
-      key: `key-mmb.tickets.boarding_pass`,
-      params: {
-        boardingPassUrl: idx(this.props, _ => _.data.boardingPassUrl),
-      },
+    this.props.navigation.navigate('mmb.tickets.boarding_pass', {
+      boardingPassUrl: idx(this.props, _ => _.data.boardingPassUrl),
     });
   };
 

--- a/app/MMB/src/scenes/timeline/events/DownloadBoardingPassTimelineEvent.js
+++ b/app/MMB/src/scenes/timeline/events/DownloadBoardingPassTimelineEvent.js
@@ -25,11 +25,7 @@ type Props = {|
 
 class DownloadBoardingPassTimelineEvent extends React.Component<Props> {
   navigate = (key: RouteNamesType, params?: Object) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-      params,
-    });
+    this.props.navigation.navigate(key, params);
   };
 
   handleOpenBoardingPass = () => {

--- a/app/MMB/src/scenes/timeline/events/DownloadETicketTimelineEvent.js
+++ b/app/MMB/src/scenes/timeline/events/DownloadETicketTimelineEvent.js
@@ -24,11 +24,7 @@ type Props = {|
 
 class DownloadETicketTimelineEvent extends React.Component<Props> {
   navigate = (key: RouteNamesType, params?: Object) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-      params,
-    });
+    this.props.navigation.navigate(key, params);
   };
 
   handleOpenETicket = () => {

--- a/app/MMB/src/scenes/timeline/events/DownloadInvoiceTimelineEvent.js
+++ b/app/MMB/src/scenes/timeline/events/DownloadInvoiceTimelineEvent.js
@@ -65,10 +65,7 @@ function renderLegs(legs) {
 
 class DownloadInvoiceTimelineEvent extends React.Component<Props> {
   navigate = (key: RouteNamesType) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-    });
+    this.props.navigation.navigate(key);
   };
 
   handleOpenInvoice = () => {

--- a/app/MMB/src/scenes/timeline/events/components/ExploreAirportButton.js
+++ b/app/MMB/src/scenes/timeline/events/components/ExploreAirportButton.js
@@ -15,11 +15,7 @@ type Props = {|
 |};
 class ExploreAirportButton extends React.Component<Props> {
   navigate = (key: RouteNamesType, params?: Object) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-      params,
-    });
+    this.props.navigation.navigate(key, params);
   };
 
   handleOpenExplore = () => {

--- a/app/MMB/src/scenes/travelDocument/menuItem/TravelDocumentPassengerMenuItem.js
+++ b/app/MMB/src/scenes/travelDocument/menuItem/TravelDocumentPassengerMenuItem.js
@@ -23,15 +23,11 @@ const TravelDocumentPassengerMenuItem = (props: Props) => {
   const expiryDate = idx(props.data, _ => _.travelDocument.expiration) || null;
 
   function onPress() {
-    props.navigation.navigate({
-      routeName: 'TravelDocumentModalScreen',
-      key: 'key-TravelDocumentModalScreen',
-      params: {
-        title,
-        fullName,
-        idNumber,
-        expiryDate,
-      },
+    props.navigation.navigate('TravelDocumentModalScreen', {
+      title,
+      fullName,
+      idNumber,
+      expiryDate,
     });
   }
 

--- a/app/MMB/src/scenes/tripServices/TripServices.js
+++ b/app/MMB/src/scenes/tripServices/TripServices.js
@@ -31,11 +31,7 @@ type Props = {|
 
 export default class TripServices extends React.Component<Props> {
   navigate = (key: RouteNamesType, params?: Object) => {
-    this.props.navigation.navigate({
-      routeName: key,
-      key: `key-${key}`,
-      params,
-    });
+    this.props.navigation.navigate(key, params);
   };
 
   openWebview = (url: string) => {

--- a/app/MMB/src/scenes/tripServices/insurance/InsuranceOverviewScene.js
+++ b/app/MMB/src/scenes/tripServices/insurance/InsuranceOverviewScene.js
@@ -24,10 +24,7 @@ type Props = {|
 
 class InsuranceOverviewScene extends React.Component<Props> {
   navigate = (routeName: RouteNamesType) => {
-    this.props.navigation.navigate({
-      routeName,
-      key: 'key-' + routeName,
-    });
+    this.props.navigation.navigate(routeName);
   };
 
   goToTheInsurancePayment = () => {

--- a/app/MMB/src/scenes/tripServices/insurance/menuItem/PassengerInsuranceMenuItem.js
+++ b/app/MMB/src/scenes/tripServices/insurance/menuItem/PassengerInsuranceMenuItem.js
@@ -23,16 +23,12 @@ const PassengerInsuranceMenuItem = (props: Props) => {
   const databaseId = idx(props, _ => _.data.databaseId);
 
   function onPress() {
-    props.navigation.navigate({
-      routeName: 'mmb.trip_services.insurance.selection',
-      key: 'key-mmb.trip_services.insurance.selection',
-      params: {
-        fullName,
-        title,
-        birthday,
-        databaseId,
-        insuranceType,
-      },
+    props.navigation.navigate('mmb.trip_services.insurance.selection', {
+      fullName,
+      title,
+      birthday,
+      databaseId,
+      insuranceType,
     });
   }
   return (

--- a/app/core/src/screens/homepage/Homepage.js
+++ b/app/core/src/screens/homepage/Homepage.js
@@ -23,53 +23,34 @@ function Section({ children }: { children: React.Node }) {
 }
 
 export default class Homepage extends React.Component<Props> {
-  goToAllHotelsPage = () =>
-    this.props.navigation.navigate({
-      routeName: 'HotelsPackage',
-      key: 'key-HotelsPackage',
-    });
+  goToAllHotelsPage = () => this.props.navigation.navigate('HotelsPackage');
 
   goToOslo = () => {
-    this.props.navigation.navigate({
-      routeName: 'HotelsPackage',
-      key: 'key-HotelsPackage',
-      params: {
-        coordinates: {
-          latitude: 59.9139,
-          longitude: 10.7522,
-        },
+    this.props.navigation.navigate('HotelsPackage', {
+      coordinates: {
+        latitude: 59.9139,
+        longitude: 10.7522,
       },
     });
   };
 
   goToLima = () => {
-    this.props.navigation.navigate({
-      routeName: 'HotelsPackage',
-      key: 'key-HotelsPackage',
-      params: {
-        coordinates: {
-          latitude: -12.046374,
-          longitude: -77.042793,
-        },
+    this.props.navigation.navigate('HotelsPackage', {
+      coordinates: {
+        latitude: -12.046374,
+        longitude: -77.042793,
       },
     });
   };
 
   goToSingleHotel = () => {
-    this.props.navigation.navigate({
-      routeName: 'SingleHotelPackage',
-      key: 'key-SingleHotelPackage',
-    });
+    this.props.navigation.navigate('SingleHotelPackage');
   };
 
   searchWithDates = () => {
-    this.props.navigation.navigate({
-      routeName: 'HotelsPackage',
-      key: 'key-HotelsPackage',
-      params: {
-        checkin: DateFormatter(DateUtils().addDays(30)).formatForMachine(),
-        checkout: DateFormatter(DateUtils().addDays(36)).formatForMachine(),
-      },
+    this.props.navigation.navigate('HotelsPackage', {
+      checkin: DateFormatter(DateUtils().addDays(30)).formatForMachine(),
+      checkout: DateFormatter(DateUtils().addDays(36)).formatForMachine(),
     });
   };
 

--- a/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
+++ b/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
@@ -42,10 +42,7 @@ export default class AllHotelsNavigationScreen extends React.Component<Props> {
     }
 
     function goToAllHotelsMap() {
-      props.navigation.navigate({
-        routeName: 'AllHotelsMap',
-        key: 'key-AllHotelsMap',
-      });
+      props.navigation.navigate('AllHotelsMap');
     }
 
     return {
@@ -76,28 +73,15 @@ export default class AllHotelsNavigationScreen extends React.Component<Props> {
   };
 
   openLocationPicker = (location: string | null) => {
-    this.props.navigation.navigate({
-      routeName: 'LocationPicker',
-      key: 'key-LocationPicker',
-      params: {
-        location,
-      },
-    });
+    this.props.navigation.navigate('LocationPicker', { location });
   };
 
   openGuestsModal = () => {
-    this.props.navigation.navigate({
-      routeName: 'GuestsModal',
-      key: 'key-GuestsModal',
-    });
+    this.props.navigation.navigate('GuestsModal');
   };
 
   openSingleHotel = (searchParams: any) =>
-    this.props.navigation.navigate({
-      routeName: 'SingleHotel',
-      key: 'key-SingleHotel',
-      params: searchParams,
-    });
+    this.props.navigation.navigate('SingleHotel', searchParams);
 
   render = () => {
     return (

--- a/app/hotels/src/navigation/allHotelsMap/AllHotelsMapNavigationScreen.js
+++ b/app/hotels/src/navigation/allHotelsMap/AllHotelsMapNavigationScreen.js
@@ -28,11 +28,7 @@ export default class AllHotelsMapNavigationScreen extends React.Component<
   };
 
   goToHotel = (searchParams: AvailableHotelSearchInput) => {
-    return this.props.navigation.navigate({
-      routeName: 'SingleHotel',
-      key: 'key-SingleHotel',
-      params: searchParams,
-    });
+    return this.props.navigation.navigate('SingleHotel', searchParams);
   };
 
   render = () => (

--- a/app/hotels/src/navigation/singleHotel/AdditionalPropsInjector.js
+++ b/app/hotels/src/navigation/singleHotel/AdditionalPropsInjector.js
@@ -17,14 +17,10 @@ export default class AdditionalPropsInjecter extends React.Component<
     highResImages: string[],
     imageIndex: number,
   ) => {
-    this.props.navigation.navigate({
-      routeName: 'GalleryStripe',
-      key: 'key-GalleryStripe',
-      params: {
-        hotelName,
-        imageUrls: highResImages,
-        index: imageIndex,
-      },
+    this.props.navigation.navigate('GalleryStripe', {
+      hotelName,
+      imageUrls: highResImages,
+      index: imageIndex,
     });
   };
 

--- a/app/hotels/src/navigation/singleHotel/SingleHotelNavigationScreen.js
+++ b/app/hotels/src/navigation/singleHotel/SingleHotelNavigationScreen.js
@@ -53,42 +53,30 @@ class SingleHotelNavigationScreen extends React.Component<Props> {
   };
 
   goToGalleryGrid = (hotelName: string, images: any) => {
-    this.props.navigation.navigate({
-      routeName: 'GalleryGrid',
-      key: 'key-GalleryGrid',
-      params: {
-        hotelName,
-        images,
-      },
+    this.props.navigation.navigate('GalleryGrid', {
+      hotelName,
+      images,
     });
   };
 
   goToPayment = (parameters: Object) => {
-    this.props.navigation.navigate({
-      routeName: 'Payment',
-      key: 'key-Payment',
-      params: {
-        ...parameters,
-        checkin: this.props.checkin,
-        checkout: this.props.checkout,
-        affiliateId: this.props.bookingComAffiliate,
-        language: this.props.language,
-        currency: this.props.currency,
-      },
+    this.props.navigation.navigate('Payment', {
+      ...parameters,
+      checkin: this.props.checkin,
+      checkout: this.props.checkout,
+      affiliateId: this.props.bookingComAffiliate,
+      language: this.props.language,
+      currency: this.props.currency,
     });
   };
 
   goToMap = () => {
-    this.props.navigation.navigate({
-      routeName: 'SingleHotelMap',
-      key: 'key-SingleHotelMap',
-      params: {
-        hotelId: this.props.hotelId,
-        checkin: this.props.checkin,
-        checkout: this.props.checkout,
-        roomsConfiguration: this.props.roomsConfiguration,
-        currency: this.props.currency,
-      },
+    this.props.navigation.navigate('SingleHotelMap', {
+      hotelId: this.props.hotelId,
+      checkin: this.props.checkin,
+      checkout: this.props.checkout,
+      roomsConfiguration: this.props.roomsConfiguration,
+      currency: this.props.currency,
     });
   };
 

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@kiwicom/mobile-localization": "^0",
     "@kiwicom/mobile-shared": "^0",
-    "react-navigation": "^2.6.2",
+    "react-navigation": "^2.8.0",
     "react-navigation-props-mapper": "^0.1.2"
   }
 }

--- a/packages/navigation/types/Navigation.js
+++ b/packages/navigation/types/Navigation.js
@@ -62,14 +62,19 @@ export type NavigationListener = (
 ) => { remove: () => void };
 
 /**
- * @see https://reactnavigation.org/docs/navigators/navigation-prop
+ * Based on official types with custom changes (like RouteNames)
+ * @see https://github.com/flow-typed/flow-typed/tree/master/definitions/npm/react-navigation_v2.x.x
  */
 export type Navigation = {
-  navigate: ({
-    routeName: RouteNames,
-    key: string, // should be unique
+  navigate: (
+    routeName:
+      | RouteNames
+      | {|
+          routeName: RouteNames,
+          params?: NavigationStateParameters,
+        |},
     params?: NavigationStateParameters,
-  }) => void,
+  ) => void, // In fact it returns boolean but we don't care of this result
   state: {
     params: NavigationStateParameters,
   },

--- a/packages/playground/src/PlaygroundList.js
+++ b/packages/playground/src/PlaygroundList.js
@@ -42,13 +42,9 @@ export class PlaygroundList extends React.Component<Props> {
 
   navigateToPlayground = (name: string) => {
     this.props.saveToStorage(name);
-    this.props.navigation.navigate({
-      routeName: 'Playground',
-      key: 'key-Playground',
-      params: {
-        name,
-        onGoBack: this.onBackClicked,
-      },
+    this.props.navigation.navigate('Playground', {
+      name,
+      onGoBack: this.onBackClicked,
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5873,9 +5873,9 @@ react-navigation-tabs@0.5.1:
     react-native-safe-area-view "^0.7.0"
     react-native-tab-view "^1.0.0"
 
-react-navigation@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-2.6.2.tgz#a8fdb69c5876698f7e58c5a3962a78ba24bb2058"
+react-navigation@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-2.8.0.tgz#c7f07a8d97ac99fa872e655783ad0a71563a9094"
   dependencies:
     clamp "^1.0.1"
     create-react-context "^0.2.1"


### PR DESCRIPTION
Fixes #898.

We did some investigation: https://snack.expo.io/SyECyLk4Q.

Therefore, we do not need `key` anymore to avoid pushing a screen twice. Using `navigate` is enough. 

- [x] Write new types
- [x] Refactor all `navigate` that are failing right now due the Flow refactor