### PR TITLE
Using createStackNavigator instead of deprecated StackNavigator

### DIFF
--- a/packages/navigation/index.js
+++ b/packages/navigation/index.js
@@ -76,7 +76,10 @@ export const StackNavigator = (
     +headerMode?: 'none',
   |},
 ) => {
-  return ReactNavigation.StackNavigator(RouteConfigs, StackNavigatorConfig);
+  return ReactNavigation.createStackNavigator(
+    RouteConfigs,
+    StackNavigatorConfig,
+  );
 };
 
 export const StackNavigatorOptions = {


### PR DESCRIPTION
Removes some warnings in the console

There still is this warning concerning navigators though: 

```
You should only render one navigator explicitly in your app, and other navigators should by rendered by including them in that navigator. Full details at: https://reactnavigation.org/docs/common-mistakes.html#explicitly-rendering-more-than-one-navigator
```