### PR TITLE
MMB: Move split screen navigation active id to context

### DIFF
--- a/app/MMB/index.js
+++ b/app/MMB/index.js
@@ -15,6 +15,7 @@ import WalletContext from './src/context/WalletContext';
 import TravelDocumentFormContext from './src/scenes/travelDocument/form/TravelDocumentFormContext';
 import InsuranceOverviewContext from './src/scenes/tripServices/insurance/insuranceOverviewScene/InsuranceOverviewSceneContext';
 import HotelsContext from './src/context/HotelsContext';
+import SplitNavigationContext from './src/context/SplitNavigationContext';
 
 type Props = {|
   +currency: string,
@@ -45,9 +46,13 @@ class ManageMyBookingPackage extends React.Component<Props> {
                   dataSaverEnabled={this.props.dataSaverEnabled}
                   bookingComAffiliate={this.props.bookingComAffiliate}
                 >
-                  <NavigationStack
-                    onNavigationStateChange={this.props.onNavigationStateChange}
-                  />
+                  <SplitNavigationContext.Provider>
+                    <NavigationStack
+                      onNavigationStateChange={
+                        this.props.onNavigationStateChange
+                      }
+                    />
+                  </SplitNavigationContext.Provider>
                 </HotelsContext.Provider>
               </InsuranceOverviewContext.Provider>
             </TravelDocumentFormContext.Provider>

--- a/app/MMB/src/context/SplitNavigationContext.js
+++ b/app/MMB/src/context/SplitNavigationContext.js
@@ -1,0 +1,66 @@
+// @flow
+
+import * as React from 'react';
+
+const defaultState = {
+  activeId: 'mmb.trip_overview',
+  actions: {
+    setActiveId: () => {},
+  },
+};
+
+const { Consumer, Provider: ContextProvider } = React.createContext({
+  ...defaultState,
+});
+
+type Props = {|
+  +children: React.Node,
+|};
+
+type State = {|
+  activeId: string,
+  +actions: {|
+    +setActiveId: (activeId: string) => void,
+  |},
+|};
+
+class Provider extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      ...defaultState,
+      actions: {
+        setActiveId: this.setActiveId,
+      },
+    };
+  }
+
+  setActiveId = (activeId: string) => {
+    this.setState({ activeId });
+  };
+
+  render = () => (
+    <ContextProvider value={this.state}>{this.props.children}</ContextProvider>
+  );
+}
+
+export default { Consumer, Provider };
+
+export const withSplitNavigationContext = (Component: React.ElementType) => {
+  const WithSplitNavigationContext = (props: Object) => {
+    return (
+      <Consumer>
+        {({ activeId, actions: { setActiveId } }) => (
+          <Component {...props} activeId={activeId} setActiveId={setActiveId} />
+        )}
+      </Consumer>
+    );
+  };
+
+  // $FlowExpectedError: We need to pass on the navigationOptions if any, flow does not know about it, but a react component might have it
+  if (Component.navigationOptions) {
+    WithSplitNavigationContext.navigationOptions = Component.navigationOptions;
+  }
+  return WithSplitNavigationContext;
+};

--- a/app/MMB/src/context/__tests__/SplitNavigationContext.test.js
+++ b/app/MMB/src/context/__tests__/SplitNavigationContext.test.js
@@ -1,0 +1,34 @@
+// @flow
+
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+
+import SplitNavigationContext from '../SplitNavigationContext';
+
+class ContextConsumer extends React.Component<{}> {
+  render = () => null;
+}
+
+const getWrapper = () =>
+  renderer.create(
+    <SplitNavigationContext.Provider>
+      <SplitNavigationContext.Consumer>
+        {({ actions: { setActiveId }, activeId }) => (
+          <ContextConsumer activeId={activeId} setActiveId={setActiveId} />
+        )}
+      </SplitNavigationContext.Consumer>
+    </SplitNavigationContext.Provider>,
+  );
+
+describe('SplitNavigationContext', () => {
+  it('sets active id', () => {
+    const wrapper = getWrapper();
+    const instance = wrapper.root.findByType(ContextConsumer);
+    const newActiveId = 'active-lol';
+
+    expect(instance.props.activeId).not.toEqual(newActiveId);
+
+    instance.props.setActiveId(newActiveId);
+    expect(instance.props.activeId).toEqual(newActiveId);
+  });
+});

--- a/app/MMB/src/navigation/DetailScreen.js
+++ b/app/MMB/src/navigation/DetailScreen.js
@@ -21,6 +21,7 @@ import TripServices, {
 import PassengerDetailContainer from '../scenes/passenger/PassengerDetailContainer';
 import TripOverviewTablet from '../scenes/tripOverview/TripOverviewTablet';
 import Timeline, { TimelineSubmenuItems } from '../scenes/timeline/Timeline';
+import { withSplitNavigationContext } from '../context/SplitNavigationContext';
 
 export const MenuComponents = {
   'mmb.trip_overview': {
@@ -106,17 +107,11 @@ export const MenuComponents = {
 
 type Props = {|
   +navigation: NavigationType,
+  +activeId: string,
+  +setActiveId: (activeId: string) => void,
 |};
 
-type State = {|
-  activeContainerComponent: string,
-|};
-
-export default class DetailsScreen extends React.Component<Props, State> {
-  state = {
-    activeContainerComponent: 'mmb.trip_overview',
-  };
-
+class DetailsScreen extends React.Component<Props> {
   static navigationOptions = (props: {| navigation: NavigationType |}) => {
     const params = props.navigation.state.params;
 
@@ -153,9 +148,7 @@ export default class DetailsScreen extends React.Component<Props, State> {
    */
   changeContentOnTablet = (key: string) => {
     this.props.navigation.setParams({ activeContainerComponent: key });
-    this.setState({
-      activeContainerComponent: key,
-    });
+    this.props.setActiveId(key);
   };
 
   getContainerComponent = (key: string) => {
@@ -163,9 +156,8 @@ export default class DetailsScreen extends React.Component<Props, State> {
   };
 
   render = () => {
-    const ContainerComponent = this.getContainerComponent(
-      this.state.activeContainerComponent,
-    ).screen;
+    const ContainerComponent = this.getContainerComponent(this.props.activeId)
+      .screen;
 
     return (
       <LayoutDoubleColumn
@@ -186,3 +178,5 @@ export default class DetailsScreen extends React.Component<Props, State> {
     );
   };
 }
+
+export default withSplitNavigationContext(DetailsScreen);

--- a/app/MMB/src/scenes/tripServices/hotelMenuItem/HotelMenuItem.js
+++ b/app/MMB/src/scenes/tripServices/hotelMenuItem/HotelMenuItem.js
@@ -88,7 +88,7 @@ export class HotelMenuItem extends React.Component<PropsWithContext, State> {
       checkin: sanitizedDates.checkin,
       checkout: sanitizedDates.checkout,
       onNavigationStateChange: () => {}, // TODO
-      onBackClicked: this.goBack, // TODO: Needs tuning on tablet
+      onBackClicked: this.goBack,
       dimensions: this.props.dimensions,
       version: this.props.version,
       cityName,


### PR DESCRIPTION
This is necessary since switchNavigator unmounts MMB stack, meaning that activeComponentId is lost. Moving it to context will persist it, so we are at correct navigation on tablet when we close Hotels modal.