### PR TITLE
Move currency to rnmodules

### DIFF
--- a/app/core/config/NativeModulesMocks/RNCurrencyManager.js
+++ b/app/core/config/NativeModulesMocks/RNCurrencyManager.js
@@ -4,5 +4,4 @@ import { NativeModules } from 'react-native';
 
 NativeModules.RNCurrencyManager = {
   formatAmount: jest.fn((price: number) => price),
-  formatAmountAsync: jest.fn((price: number) => price),
 };

--- a/ios/RNModules/RNCurrencyManager/RNCurrencyManager/RNCurrencyManager.m
+++ b/ios/RNModules/RNCurrencyManager/RNCurrencyManager/RNCurrencyManager.m
@@ -41,11 +41,7 @@ RCT_EXPORT_MODULE();
     return _formatter;
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(formatAmount:(nonnull NSNumber *)amountInEUR toCurrency:(NSString *)currency) {
-    return [[self formatter] formatAmount:amountInEUR toCurrency:currency];
-}
-
-RCT_EXPORT_METHOD(formatAmountAsync:(nonnull NSNumber *)amountInEUR toCurrency:(NSString *)currency
+RCT_EXPORT_METHOD(formatAmount:(nonnull NSNumber *)amountInEUR toCurrency:(NSString *)currency
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *formattedAmount = [[self formatter] formatAmount:amountInEUR toCurrency:currency];

--- a/packages/rnmodules/currency/CurrencyFormatter.js
+++ b/packages/rnmodules/currency/CurrencyFormatter.js
@@ -1,0 +1,5 @@
+// @flow
+
+import { NativeModules } from 'react-native';
+
+export const formatAmount = NativeModules.RNCurrencyManager.formatAmount;

--- a/packages/rnmodules/currency/README.md
+++ b/packages/rnmodules/currency/README.md
@@ -1,0 +1,9 @@
+# CurrencyFormatter
+
+ It exposes the following methods:
+
+ ## formatAmount
+
+ ```js
+formatAmount(price: Number, toCurrency: string) => Promise<Number>
+```

--- a/packages/rnmodules/index.js
+++ b/packages/rnmodules/index.js
@@ -2,3 +2,4 @@
 
 export { translate } from './translation/TranslationManager';
 export { translateAsync } from './translation/TranslationManager';
+export { formatAmount } from './currency/CurrencyFormatter';

--- a/packages/shared/src/CurrencyFormatter.js
+++ b/packages/shared/src/CurrencyFormatter.js
@@ -1,14 +1,11 @@
 // @flow strict
 
-import { NativeModules } from 'react-native';
+import { formatAmount } from '@kiwicom/rnmodules';
 
 export default async function CurrencyFormatter(
   price: number,
   toCurrency: string,
 ) {
-  const formattedAmount = await NativeModules.RNCurrencyManager.formatAmountAsync(
-    price,
-    toCurrency,
-  );
+  const formattedAmount = await formatAmount(price, toCurrency);
   return formattedAmount;
 }

--- a/packages/shared/src/__tests__/CurrencyFormatter.test.js
+++ b/packages/shared/src/__tests__/CurrencyFormatter.test.js
@@ -1,14 +1,12 @@
 // @flow
 
-import { NativeModules } from 'react-native';
+import { formatAmount } from '@kiwicom/rnmodules';
 
 import CurrencyFormatter from '../CurrencyFormatter';
 
 describe('CurrencyFormatter', () => {
-  it('should call NativeModules.RNCurrencyManager.formatAmountAsync', async () => {
+  it('should call formatAmount', async () => {
     await CurrencyFormatter(100, 'USD');
-    expect(
-      NativeModules.RNCurrencyManager.formatAmountAsync,
-    ).toHaveBeenCalledWith(100, 'USD');
+    expect(formatAmount).toHaveBeenCalledWith(100, 'USD');
   });
 });


### PR DESCRIPTION
* move `RNCurrencyManager` to `rnmodules`
* remove `formatAmount` method
NOTE: Current `formatAmount` method is former `formatAsyncAmount`