### PR TITLE
Use live dates instead of fixed

### DIFF
--- a/app/native.js
+++ b/app/native.js
@@ -1,10 +1,19 @@
 // @flow
 
-import { AppRegistry } from 'react-native';
+import { AppRegistry, YellowBox } from 'react-native';
 import {
   SingleHotelStandalonePackage,
   NewHotelsStandAlonePackage,
 } from '@kiwicom/react-native-app-hotels';
+
+// TODO: please check if it's still needed
+YellowBox.ignoreWarnings([
+  // react-native-share warnings. Should be gone with the version 1.1.3
+  'Class GenericShare was not exported. Did you forget to use RCT_EXPORT_MODULE()',
+  'Class WhatsAppShare was not exported. Did you forget to use RCT_EXPORT_MODULE()',
+  'Class GooglePlusShare was not exported. Did you forget to use RCT_EXPORT_MODULE()',
+  'Class InstagramShare was not exported. Did you forget to use RCT_EXPORT_MODULE()',
+]);
 
 // Hotels
 AppRegistry.registerComponent(

--- a/ios/RNNativePlayground/ViewController.m
+++ b/ios/RNNativePlayground/ViewController.m
@@ -46,6 +46,11 @@
 }
 
 - (IBAction)presentNewHotelsView:(id)sender {
+  NSDateFormatter *dateFormatter =[[NSDateFormatter alloc] init];
+  [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+  NSString *todayDate = [dateFormatter stringFromDate:[NSDate date]];
+  NSString *tomorrowDate = [dateFormatter stringFromDate:[[NSDate date] dateByAddingTimeInterval:86400]];
+  
     RNKiwiViewController *vc = [[RNKiwiViewController alloc] initWithModule:@"NewKiwiHotels"
                                                           initialProperties:@{
                                                             @"bookingComAffiliate": @"123456",
@@ -53,8 +58,8 @@
                                                             @"currency": @"EUR",
                                                             @"lastNavigationMode": @"present",
                                                             @"dimensions": [self windowDimensions],
-                                                            @"checkin": @"2018-09-20",
-                                                            @"checkout": @"2018-09-22",
+                                                            @"checkin": todayDate,
+                                                            @"checkout": tomorrowDate,
                                                             @"version": @"3.7.13-9d55ad66",
                                                             @"cityName": @"Barcelona",
                                                             @"cityId": @"aG90ZWxDaXR5Oi0zNzI0OTA=",


### PR DESCRIPTION
Small improvement:

* replace fixed dates for live dates
* ignore warnings in the playground come from `react-native-share` -> remove when v. 1.1.3 will be released