### PR TITLE
Fix building Android Playground on Debug mode

### DIFF
--- a/android/playground/build.gradle
+++ b/android/playground/build.gradle
@@ -60,6 +60,7 @@ android {
             // Note: CodePush updates should not be tested in Debug mode as they are overriden by the RN packager.
             // However, because CodePush checks for updates in all modes, we must supply a key.
             buildConfigField "String", "CODEPUSH_KEY", '""'
+            buildConfigField "String", "CODEPUSH_VERSION", '""'
         }
         stagingRelease {
             buildConfigField "String", "CODEPUSH_KEY", "\"${stageCodePushKey}\""


### PR DESCRIPTION
Bug was introduced with CodePush.