### PR TITLE
Fix: blackList package.json from iOS build folder

### DIFF
--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -15,6 +15,7 @@ const sharedBlacklist = [
   /website\/node_modules\/.*/,
   /heapCapture\/bundle\.js/,
   /\.build[/\\].*/,
+  /ios[/\\]build[/\\]Build[/\\].*/,
   // /.*\/__tests__\/.*/,
 ];
 


### PR DESCRIPTION
This is happening because iOS references `package.json` as resource, as it needs to read code push version from there.