### PR TITLE
Localization: have translation render null instead of string null when passThrough is undefined

### DIFF
--- a/packages/localization/src/Translation.js
+++ b/packages/localization/src/Translation.js
@@ -71,6 +71,9 @@ export default class Translation extends React.Component<Props> {
     if (this.props.id === undefined) {
       // ID prop is missing so let's assume it's "pass through" translation
       // (property passThrough may be undefined)
+      if (this.props.passThrough == null) {
+        return null;
+      }
       return (
         <Text style={containerStyle}>
           {/* $FlowExpectedError: we do not allow to use 'string' in the 'Text' components but translations are exceptions. */}

--- a/packages/localization/src/__tests__/__snapshots__/Translation.test.js.snap
+++ b/packages/localization/src/__tests__/__snapshots__/Translation.test.js.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`works with optional pass through parameter 1`] = `
-<Text>
-  undefined
-</Text>
-`;
+exports[`works with optional pass through parameter 1`] = `null`;
 
 exports[`works with pass through translations 1`] = `
 <Text>


### PR DESCRIPTION
closes #1311 