### PR TITLE
Workaround for not linking CodePush on "app"

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,8 +155,8 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-code-push')
     implementation project(':react-native-gesture-handler')
-    implementation project(':react-native-code-push')
     implementation project(':react-native-zip-archive')
     implementation project(':react-native-share')
     implementation project(':react-native-pdf')

--- a/ios/reactNativeApp.xcodeproj/project.pbxproj
+++ b/ios/reactNativeApp.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
@@ -853,7 +852,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kiwi.mobile.rniosplayground;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Staging;
@@ -1019,7 +1017,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kiwi.mobile.rniosplayground;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
Fixes #1374.

This is a nasty workaround. We need to use `compile` instead of `implementation` or linking command will link it again.

Soon we can get rid of all of this when CLI is not preview here https://github.com/react-native-community/react-native-cli/pull/30 anymore.