### PR TITLE
Refactor price component to take amount and currency props

### DIFF
--- a/app/MMB/src/scenes/tripServices/insurance/insuranceOverviewScene/orderSummary/InsuranceRow.js
+++ b/app/MMB/src/scenes/tripServices/insurance/insuranceOverviewScene/orderSummary/InsuranceRow.js
@@ -98,7 +98,7 @@ export function InsuranceRow(props: Props) {
           />
         </Text>
       </View>
-      <Price price={{ amount, currency }} style={styleSheet.price} />
+      <Price amount={amount} currency={currency} style={styleSheet.price} />
     </View>
   );
 }

--- a/app/MMB/src/scenes/tripServices/insurance/insuranceOverviewScene/orderSummary/OrderSummary.js
+++ b/app/MMB/src/scenes/tripServices/insurance/insuranceOverviewScene/orderSummary/OrderSummary.js
@@ -66,7 +66,11 @@ class OrderSummary extends React.Component<Props, State> {
                 <Translation id="mmb.trip_services.order.total" />
               </Text>
             </View>
-            <Price price={this.props.price} style={styleSheet.price} />
+            <Price
+              amount={this.props.price.amount}
+              currency={this.props.price.currency}
+              style={styleSheet.price}
+            />
           </View>
         </View>
       </TouchableWithoutFeedback>

--- a/app/MMB/src/scenes/tripServices/insurance/insuranceOverviewScene/orderSummary/__tests__/InsuranceRow.test.js
+++ b/app/MMB/src/scenes/tripServices/insurance/insuranceOverviewScene/orderSummary/__tests__/InsuranceRow.test.js
@@ -51,8 +51,8 @@ describe('InsuranceRow', () => {
       />,
     );
     const price = travelPlus.root.findByType(Price);
-    expect(price.props.price.amount).toBe(48.96);
-    expect(price.props.price.currency).toBe('EUR');
+    expect(price.props.amount).toBe(48.96);
+    expect(price.props.currency).toBe('EUR');
 
     const translations = travelPlus.root.findAllByType(Translation);
     expect(translations[0].props.values.quantity).toBe(2);
@@ -80,8 +80,9 @@ describe('InsuranceRow', () => {
       />,
     );
     const price = travelBasic.root.findByType(Price);
-    expect(price.props.price.amount).toBe(-18.32);
-    expect(price.props.price.currency).toBe('EUR');
+
+    expect(price.props.amount).toBe(-18.32);
+    expect(price.props.currency).toBe('EUR');
 
     const translations = travelBasic.root.findAllByType(Translation);
     expect(translations[0].props.values.quantity).toBe(1);
@@ -114,8 +115,8 @@ describe('InsuranceRow', () => {
       />,
     );
     const price = none.root.findByType(Price);
-    expect(price.props.price.amount).toBe(-61.28);
-    expect(price.props.price.currency).toBe('EUR');
+    expect(price.props.amount).toBe(-61.28);
+    expect(price.props.currency).toBe('EUR');
 
     const translations = none.root.findAllByType(Translation);
     expect(translations[0].props.values.quantity).toBe(2);

--- a/app/MMB/src/scenes/tripServices/insurance/insuranceSelectionScene/variantButtons/Price.js
+++ b/app/MMB/src/scenes/tripServices/insurance/insuranceSelectionScene/variantButtons/Price.js
@@ -31,7 +31,13 @@ const Price = (props: Props) => {
       </Text>
     );
   } else if (price && price.amount != null && price.currency != null) {
-    return <OriginalPrice price={price} style={style} />;
+    return (
+      <OriginalPrice
+        amount={price.amount}
+        currency={price.currency}
+        style={style}
+      />
+    );
   }
   return (
     <Text style={style}>

--- a/app/hotels/src/allHotels/HotelTitle.js
+++ b/app/hotels/src/allHotels/HotelTitle.js
@@ -1,6 +1,5 @@
 // @flow strict
 
-/* eslint-disable relay/unused-fields */
 import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
@@ -31,7 +30,11 @@ function HotelTitle({ data }: Props) {
       <View style={style.distance}>
         <Distance hotel={data} />
       </View>
-      <Price price={data.price} style={style.price} />
+      <Price
+        amount={data.price?.amount}
+        currency={data.price?.currency}
+        style={style.price}
+      />
     </React.Fragment>
   );
 }

--- a/app/hotels/src/filter/price/PriceFilter.js
+++ b/app/hotels/src/filter/price/PriceFilter.js
@@ -91,12 +91,7 @@ class PriceFilter extends React.Component<PropsWithContext, State> {
       return (
         <TranslationFragment>
           <Translation passThrough="< " />
-          <Price
-            price={{
-              amount: end * daysOfStay,
-              currency: currency,
-            }}
-          />
+          <Price amount={end * daysOfStay} currency={currency} />
         </TranslationFragment>
       );
     }
@@ -104,30 +99,15 @@ class PriceFilter extends React.Component<PropsWithContext, State> {
       return (
         <TranslationFragment>
           <Translation passThrough="> " />
-          <Price
-            price={{
-              amount: start * daysOfStay,
-              currency: currency,
-            }}
-          />
+          <Price amount={start * daysOfStay} currency={currency} />
         </TranslationFragment>
       );
     }
     return (
       <TranslationFragment>
-        <Price
-          price={{
-            amount: start * daysOfStay,
-            currency: currency,
-          }}
-        />
+        <Price amount={start * daysOfStay} currency={currency} />
         <Translation passThrough=" - " />
-        <Price
-          price={{
-            amount: end * daysOfStay,
-            currency: currency,
-          }}
-        />
+        <Price amount={end * daysOfStay} currency={currency} />
       </TranslationFragment>
     );
   };

--- a/app/hotels/src/filter/price/PricePopup.js
+++ b/app/hotels/src/filter/price/PricePopup.js
@@ -91,22 +91,10 @@ export default class PricePopup extends React.Component<Props, State> {
             max={max}
             min={min}
             startLabel={
-              <Price
-                price={{
-                  amount: start * daysOfStay,
-                  currency,
-                }}
-              />
+              <Price amount={start * daysOfStay} currency={currency} />
             }
             startValue={start}
-            endLabel={
-              <Price
-                price={{
-                  amount: end * daysOfStay,
-                  currency,
-                }}
-              />
-            }
+            endLabel={<Price amount={end * daysOfStay} currency={currency} />}
             endValue={end}
           />
           <View style={styles.sliderContainer}>

--- a/app/hotels/src/map/allHotels/HotelSwipeItem.js
+++ b/app/hotels/src/map/allHotels/HotelSwipeItem.js
@@ -1,6 +1,5 @@
 // @flow strict
 
-/* eslint-disable relay/unused-fields */
 import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
@@ -65,7 +64,8 @@ export class HotelSwipeItemWithContext extends React.Component<PropsWithContext>
         <View style={{ width }}>
           <HotelDetailPreview
             name={name}
-            price={price}
+            amount={price?.amount}
+            currency={price?.currency}
             thumbnailUrl={thumbnailUrl}
             stars={stars}
             score={score}

--- a/app/hotels/src/map/allHotels/PriceMarker.js
+++ b/app/hotels/src/map/allHotels/PriceMarker.js
@@ -1,7 +1,5 @@
 // @flow
 
-/* eslint-disable relay/unused-fields */
-
 import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
@@ -16,7 +14,10 @@ type Props = {|
 |};
 
 const PriceMarker = (props: Props) => {
-  const { isSelected, data: price } = props;
+  const {
+    isSelected,
+    data: { amount, currency },
+  } = props;
   const bubbleStyles = StyleSheet.flatten([
     styles.bubble,
     isSelected && selectedStyles.bubble,
@@ -29,7 +30,9 @@ const PriceMarker = (props: Props) => {
   return (
     <View>
       <View style={bubbleStyles}>
-        {price != null && <Price price={price} style={priceStyles} />}
+        {props.data != null && (
+          <Price amount={amount} currency={currency} style={priceStyles} />
+        )}
       </View>
       <View style={[styles.arrowBorder]} />
       <View style={[styles.arrow, isSelected && selectedStyles.arrow]} />

--- a/app/hotels/src/map/hotelDetailPreview/HotelDetailPreview.js
+++ b/app/hotels/src/map/hotelDetailPreview/HotelDetailPreview.js
@@ -20,10 +20,8 @@ import HotelReviewScore from '../../components/HotelReviewScore';
 
 type Props = {|
   +name?: ?string,
-  +price?: ?{|
-    +currency?: ?string,
-    +amount?: ?number,
-  |},
+  +currency?: ?string,
+  +amount?: ?number,
   +thumbnailUrl?: ?string,
   +stars?: ?number,
   +score?: ?number,
@@ -31,11 +29,8 @@ type Props = {|
 
 export default class HotelDetailPreview extends React.Component<Props> {
   renderInner = ({ containerWidth }: HotelDetailState) => {
-    const name = this.props.name;
-    const price = this.props.price;
-    const image = this.props.thumbnailUrl;
+    const { name, amount, currency, thumbnailUrl: image, score } = this.props;
     const stars = this.props.stars ?? 0;
-    const score = this.props.score;
     return (
       <View style={[styles.container, { width: containerWidth }]}>
         <View>
@@ -54,7 +49,7 @@ export default class HotelDetailPreview extends React.Component<Props> {
           <View style={styles.row}>
             <View>
               {stars > 0 && <Stars rating={stars} style={styles.stars} />}
-              <Price price={price} style={styles.price} />
+              <Price amount={amount} currency={currency} style={styles.price} />
             </View>
             <HotelReviewScore score={score} />
           </View>

--- a/app/hotels/src/map/singleHotel/AdditionalInfo.js
+++ b/app/hotels/src/map/singleHotel/AdditionalInfo.js
@@ -1,6 +1,5 @@
 // @flow strict
 
-/* eslint-disable relay/unused-fields */
 import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from '@kiwicom/mobile-relay';
@@ -47,7 +46,8 @@ export class AdditionalInfo extends React.Component<Props, State> {
             <View style={styles.detailPreviewContainer}>
               <HotelDetailPreview
                 name={name}
-                price={price}
+                amount={price?.amount}
+                currency={price?.currency}
                 thumbnailUrl={thumbnailUrl}
                 stars={stars}
                 score={score}
@@ -97,7 +97,6 @@ export default createFragmentContainer(
         review {
           score
         }
-        id
         name
         mainPhoto {
           thumbnailUrl

--- a/app/hotels/src/map/singleHotel/__generated__/AdditionalInfo.graphql.js
+++ b/app/hotels/src/map/singleHotel/__generated__/AdditionalInfo.graphql.js
@@ -23,7 +23,6 @@ export type AdditionalInfo = {|
     +review: ?{|
       +score: ?number
     |},
-    +id: string,
     +name: ?string,
     +mainPhoto: ?{|
       +thumbnailUrl: ?string
@@ -115,13 +114,6 @@ const node/*: ConcreteFragment*/ = {
         {
           "kind": "ScalarField",
           "alias": null,
-          "name": "id",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
           "name": "name",
           "args": null,
           "storageKey": null
@@ -167,5 +159,5 @@ const node/*: ConcreteFragment*/ = {
   ]
 };
 // prettier-ignore
-(node/*: any*/).hash = 'f96f53c45e6c3ee4ad30f1d0ae3a3527';
+(node/*: any*/).hash = '1a8956ae64cf9872541efd73f28b5c10';
 module.exports = node;

--- a/app/hotels/src/map/singleHotel/__generated__/SingleHotelMapScreenQuery.graphql.js
+++ b/app/hotels/src/map/singleHotel/__generated__/SingleHotelMapScreenQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash b5ce6ca3f1712f723032f8b5d1eab09e
+ * @relayHash 437ebd79f8ed9dd5bd19de8b1acc7eb8
  */
 
 /* eslint-disable */
@@ -87,7 +87,6 @@ fragment AdditionalInfo on HotelAvailabilityInterface {
     review {
       score
     }
-    id
     name
     mainPhoto {
       thumbnailUrl
@@ -96,6 +95,7 @@ fragment AdditionalInfo on HotelAvailabilityInterface {
     rating {
       stars
     }
+    id
   }
 }
 
@@ -147,7 +147,7 @@ return {
   "operationKind": "query",
   "name": "SingleHotelMapScreenQuery",
   "id": null,
-  "text": "query SingleHotelMapScreenQuery(\n  $search: AvailableHotelSearchInput!\n  $options: AvailableHotelOptionsInput\n) {\n  availableHotel(search: $search, options: $options) {\n    ...SingleMap\n    id\n  }\n}\n\nfragment SingleMap on HotelAvailabilityInterface {\n  hotel {\n    __typename\n    ...MapView_hotel\n    id\n  }\n  ...AdditionalInfo\n}\n\nfragment MapView_hotel on HotelInterface {\n  coordinates {\n    lat\n    lng\n  }\n}\n\nfragment AdditionalInfo on HotelAvailabilityInterface {\n  price {\n    amount\n    currency\n  }\n  hotel {\n    __typename\n    address {\n      ...Address_address\n    }\n    review {\n      score\n    }\n    id\n    name\n    mainPhoto {\n      thumbnailUrl\n      id\n    }\n    rating {\n      stars\n    }\n  }\n}\n\nfragment Address_address on Address {\n  street\n  city\n  zip\n}\n",
+  "text": "query SingleHotelMapScreenQuery(\n  $search: AvailableHotelSearchInput!\n  $options: AvailableHotelOptionsInput\n) {\n  availableHotel(search: $search, options: $options) {\n    ...SingleMap\n    id\n  }\n}\n\nfragment SingleMap on HotelAvailabilityInterface {\n  hotel {\n    __typename\n    ...MapView_hotel\n    id\n  }\n  ...AdditionalInfo\n}\n\nfragment MapView_hotel on HotelInterface {\n  coordinates {\n    lat\n    lng\n  }\n}\n\nfragment AdditionalInfo on HotelAvailabilityInterface {\n  price {\n    amount\n    currency\n  }\n  hotel {\n    __typename\n    address {\n      ...Address_address\n    }\n    review {\n      score\n    }\n    name\n    mainPhoto {\n      thumbnailUrl\n      id\n    }\n    rating {\n      stars\n    }\n    id\n  }\n}\n\nfragment Address_address on Address {\n  street\n  city\n  zip\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",

--- a/app/hotels/src/map/singleHotel/__generated__/Stay22SingleHotelMapScreenQuery.graphql.js
+++ b/app/hotels/src/map/singleHotel/__generated__/Stay22SingleHotelMapScreenQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 036a915c3f5ac54d68f08d8feaf950f2
+ * @relayHash c2f3da45d4308d1a7b30036505f5ddd5
  */
 
 /* eslint-disable */
@@ -73,7 +73,6 @@ fragment AdditionalInfo on HotelAvailabilityInterface {
     review {
       score
     }
-    id
     name
     mainPhoto {
       thumbnailUrl
@@ -82,6 +81,7 @@ fragment AdditionalInfo on HotelAvailabilityInterface {
     rating {
       stars
     }
+    id
   }
 }
 
@@ -169,7 +169,7 @@ return {
   "operationKind": "query",
   "name": "Stay22SingleHotelMapScreenQuery",
   "id": null,
-  "text": "query Stay22SingleHotelMapScreenQuery(\n  $id: ID!\n  $guests: Int!\n  $currency: Currency\n  $checkin: Date!\n  $checkout: Date!\n) {\n  stay22HotelDetail(id: $id, guests: $guests, currency: $currency, checkin: $checkin, checkout: $checkout) {\n    ...SingleMap\n    id\n  }\n}\n\nfragment SingleMap on HotelAvailabilityInterface {\n  hotel {\n    __typename\n    ...MapView_hotel\n    id\n  }\n  ...AdditionalInfo\n}\n\nfragment MapView_hotel on HotelInterface {\n  coordinates {\n    lat\n    lng\n  }\n}\n\nfragment AdditionalInfo on HotelAvailabilityInterface {\n  price {\n    amount\n    currency\n  }\n  hotel {\n    __typename\n    address {\n      ...Address_address\n    }\n    review {\n      score\n    }\n    id\n    name\n    mainPhoto {\n      thumbnailUrl\n      id\n    }\n    rating {\n      stars\n    }\n  }\n}\n\nfragment Address_address on Address {\n  street\n  city\n  zip\n}\n",
+  "text": "query Stay22SingleHotelMapScreenQuery(\n  $id: ID!\n  $guests: Int!\n  $currency: Currency\n  $checkin: Date!\n  $checkout: Date!\n) {\n  stay22HotelDetail(id: $id, guests: $guests, currency: $currency, checkin: $checkin, checkout: $checkout) {\n    ...SingleMap\n    id\n  }\n}\n\nfragment SingleMap on HotelAvailabilityInterface {\n  hotel {\n    __typename\n    ...MapView_hotel\n    id\n  }\n  ...AdditionalInfo\n}\n\nfragment MapView_hotel on HotelInterface {\n  coordinates {\n    lat\n    lng\n  }\n}\n\nfragment AdditionalInfo on HotelAvailabilityInterface {\n  price {\n    amount\n    currency\n  }\n  hotel {\n    __typename\n    address {\n      ...Address_address\n    }\n    review {\n      score\n    }\n    name\n    mainPhoto {\n      thumbnailUrl\n      id\n    }\n    rating {\n      stars\n    }\n    id\n  }\n}\n\nfragment Address_address on Address {\n  street\n  city\n  zip\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",

--- a/app/hotels/src/singleHotel/roomPicker/IncrementDecrement.js
+++ b/app/hotels/src/singleHotel/roomPicker/IncrementDecrement.js
@@ -50,7 +50,11 @@ export default function IncrementDecrement({
               {...androidProps}
             />
           </Text>
-          <Price price={price} style={styles.price} />
+          <Price
+            amount={price?.amount}
+            currency={price?.currency}
+            style={styles.price}
+          />
         </View>
 
         <View style={styles.countContainer}>

--- a/app/hotels/src/singleHotel/roomPicker/SelectButton.js
+++ b/app/hotels/src/singleHotel/roomPicker/SelectButton.js
@@ -42,7 +42,11 @@ export default function SelectButton({
           text={<Translation id="single_hotel.room_picker.select" />}
         />
         <View style={styles.row} />
-        <Price price={price} style={styles.price} />
+        <Price
+          amount={price.amount}
+          currency={price.currency}
+          style={styles.price}
+        />
       </View>
     </Touchable>
   );

--- a/app/hotels/src/singleHotel/summary/RoomSummary.js
+++ b/app/hotels/src/singleHotel/summary/RoomSummary.js
@@ -36,7 +36,11 @@ function RoomSummary(props: Props) {
               numberOfRooms: props.numberOfRooms,
             }}
           />
-          <Price price={props.price} style={styles.currency} />
+          <Price
+            amount={props.price.amount}
+            currency={props.price.currency}
+            style={styles.currency}
+          />
         </View>
       </View>
     </View>

--- a/packages/shared/src/Price.js
+++ b/packages/shared/src/Price.js
@@ -10,13 +10,9 @@ import CancellablePromise, {
   type CancellablePromiseType,
 } from './CancellablePromise';
 
-type PriceType = {
+type Props = {|
   +amount?: ?number,
   +currency?: ?string,
-};
-
-type Props = {|
-  +price?: ?PriceType,
   +style?: StylePropType,
 |};
 
@@ -39,14 +35,11 @@ export default class Price extends React.Component<Props, State> {
     this.formatCurrency();
   }
 
-  componentDidUpdate = (prevProps: Props) => {
-    if (
-      (prevProps.price && prevProps.price.amount) !==
-      (this.props.price && this.props.price.amount)
-    ) {
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.amount !== this.props.amount) {
       this.formatCurrency();
     }
-  };
+  }
 
   componentWillUnmount = () => {
     if (this.cancellablePromise !== null) {
@@ -55,8 +48,8 @@ export default class Price extends React.Component<Props, State> {
   };
 
   formatCurrency = async () => {
-    const amount = this.props.price?.amount ?? null;
-    const currency = this.props.price?.currency || null;
+    const amount = this.props.amount ?? null;
+    const currency = this.props.currency || null;
 
     if (amount !== null && currency !== null) {
       try {

--- a/packages/shared/src/__tests__/Price.test.js
+++ b/packages/shared/src/__tests__/Price.test.js
@@ -10,7 +10,7 @@ import CurrencyFormatter from '../CurrencyFormatter';
 jest.mock('../CurrencyFormatter', () => jest.fn());
 jest.mock('../CancellablePromise', () => ({
   promise: new Promise((resolve, reject) => {
-    reject();
+    reject(new Error('err'));
   }),
 }));
 
@@ -19,27 +19,63 @@ const renderer = new ShallowRenderer();
 describe('Price', () => {
   it('renders null values correctly', () => {
     expect(
-      renderer.render(<Price price={{ amount: null, currency: null }} />),
+      renderer.render(<Price amount={null} currency={null} />),
     ).toMatchSnapshot();
     expect(
-      renderer.render(<Price price={{ amount: 45, currency: null }} />),
+      renderer.render(<Price amount={45} currency={null} />),
     ).toMatchSnapshot();
     expect(
-      renderer.render(<Price price={{ amount: null, currency: 'EUR' }} />),
+      renderer.render(<Price amount={null} currency="EUR" />),
     ).toMatchSnapshot();
   });
 
   it('calls Currencyformatter if amount and currency is passed', () => {
-    testRenderer.create(<Price price={{ amount: 45, currency: 'EUR' }} />);
+    testRenderer.create(<Price amount={45} currency="EUR" />);
     expect(CurrencyFormatter).toHaveBeenCalledWith(45, 'EUR');
   });
 
   it('does not call set state if promise is rejected', async () => {
-    const Component = new Price({ price: { amount: 45, currency: 'EUR' } });
+    const Component = new Price({ amount: 45, currency: 'EUR' });
 
     jest.spyOn(Component, 'setState');
     await Component.formatCurrency();
 
     expect(Component.setState).not.toHaveBeenCalled();
+  });
+
+  it('calls formatCurrency if amount updates', () => {
+    const Component = new Price({ amount: 45, currency: 'EUR' });
+    Component.formatCurrency = jest.fn();
+
+    Component.componentDidUpdate({ amount: 46 });
+
+    expect(Component.formatCurrency).toHaveBeenCalled();
+  });
+
+  it('does not call formatCurrency if amount is the same', () => {
+    const Component = new Price({ amount: 45, currency: 'EUR' });
+    Component.formatCurrency = jest.fn();
+
+    Component.componentDidUpdate({ amount: 45 });
+
+    expect(Component.formatCurrency).not.toHaveBeenCalled();
+  });
+
+  it('calls formatCurrency if prevProps price is undefined', () => {
+    const Component = new Price({ amount: 45, currency: 'EUR' });
+    Component.formatCurrency = jest.fn();
+
+    Component.componentDidUpdate({});
+
+    expect(Component.formatCurrency).toHaveBeenCalled();
+  });
+
+  it('calls formatCurrency if current price is undefined', () => {
+    const Component = new Price({});
+    Component.formatCurrency = jest.fn();
+
+    Component.componentDidUpdate({ amount: 45, currency: 'EUR' });
+
+    expect(Component.formatCurrency).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The motivation for this is to have the price component work with the eslint rule relay/unused-fields.
When we pass price as object, relay/unused-fields thinks we are not using amount and currency