### PR TITLE
Shared: Add fontSize prop for our icons with custom fontSize

### DIFF
--- a/app/MMB/src/scenes/tickets/__tests__/__snapshots__/TicketDeleteButton.test.js.snap
+++ b/app/MMB/src/scenes/tickets/__tests__/__snapshots__/TicketDeleteButton.test.js.snap
@@ -59,9 +59,12 @@ exports[`TicketDeleteButton renders correctly when booking has local files 1`] =
             Object {
               "color": "#00a991",
             },
-            Object {
-              "alignSelf": "flex-start",
-            },
+            Array [
+              Object {
+                "alignSelf": "flex-start",
+              },
+              null,
+            ],
           ]
         }
       >

--- a/packages/shared/src/icons/Icon.js
+++ b/packages/shared/src/icons/Icon.js
@@ -12,6 +12,7 @@ type Props = {|
   +size?: 'small' | 'medium' | 'large',
   +color?: string,
   +style?: StylePropType,
+  +fontSize?: number,
 |};
 
 export default class Icon extends React.Component<Props> {
@@ -19,7 +20,27 @@ export default class Icon extends React.Component<Props> {
     color: defaultTokens.colorIconSecondary,
   };
 
+  getCustomFontSizeStyle = () => {
+    // Universal-components adds these values based on size. We have some custom sizes in mobile
+    // So we have to override these values
+    const { fontSize } = this.props;
+
+    if (fontSize == null) {
+      return null;
+    }
+
+    return {
+      fontSize,
+      height: fontSize,
+      width: fontSize,
+      lineHeight: fontSize,
+    };
+  };
+
   render() {
-    return <UniversalIcon {...this.props} />;
+    const { style, ...rest } = this.props;
+    return (
+      <UniversalIcon {...rest} style={[style, this.getCustomFontSizeStyle()]} />
+    );
   }
 }

--- a/packages/shared/src/icons/__tests__/Icon.test.js
+++ b/packages/shared/src/icons/__tests__/Icon.test.js
@@ -13,3 +13,7 @@ it('renders for small and large', () => {
   expect(renderer.create(<Icon name="map" size="small" />)).toMatchSnapshot();
   expect(renderer.create(<Icon name="map" size="large" />)).toMatchSnapshot();
 });
+
+it('genereates correct styles for custom fontSize', () => {
+  expect(renderer.create(<Icon name="map" fontSize={12} />)).toMatchSnapshot();
+});

--- a/packages/shared/src/icons/__tests__/__snapshots__/Icon.test.js.snap
+++ b/packages/shared/src/icons/__tests__/__snapshots__/Icon.test.js.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`genereates correct styles for custom fontSize 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "orbit-icons",
+      },
+      Object {
+        "fontSize": 24,
+        "height": 24,
+        "lineHeight": 24,
+        "width": 24,
+      },
+      Object {
+        "color": "#7f91a8",
+      },
+      Array [
+        undefined,
+        Object {
+          "fontSize": 12,
+          "height": 12,
+          "lineHeight": 12,
+          "width": 12,
+        },
+      ],
+    ]
+  }
+>
+  
+</Text>
+`;
+
 exports[`renders 1`] = `
 <Text
   style={
@@ -16,7 +48,10 @@ exports[`renders 1`] = `
       Object {
         "color": "#7f91a8",
       },
-      undefined,
+      Array [
+        undefined,
+        null,
+      ],
     ]
   }
 >
@@ -40,7 +75,10 @@ exports[`renders for small and large 1`] = `
       Object {
         "color": "#7f91a8",
       },
-      undefined,
+      Array [
+        undefined,
+        null,
+      ],
     ]
   }
 >
@@ -64,7 +102,10 @@ exports[`renders for small and large 2`] = `
       Object {
         "color": "#7f91a8",
       },
-      undefined,
+      Array [
+        undefined,
+        null,
+      ],
     ]
   }
 >


### PR DESCRIPTION
Some of our icons have a custom fontSize (not orbit sizes).

We need to override width, height and lineHeight also, better to do this in the Icon component than adding this style to very single component that overrides this style