### PR TITLE
Remove node engine from package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "app/*",
     "packages/*"
   ],
-  "engines": {
-    "node": ">=11.0.0"
-  },
   "scripts": {
     "android": "yarn react-native run-android",
     "android-playground": "yarn react-native run-android --appFolder playground",
@@ -33,10 +30,11 @@
     "@kiwicom/mobile-shared": "^0",
     "@kiwicom/react-native-app-hotels": "^0",
     "@kiwicom/react-native-fast-track": "^0",
+    "chalk": "^2.4.2",
+    "detox": "^10.0.2",
     "react": "16.6.3",
     "react-native": "^0.58.3",
     "react-native-app-registry-components-to-constants": "0.0.1",
-    "detox": "^10.0.2",
     "react-native-code-push": "^5.5.2"
   },
   "peerDependencies": {

--- a/scripts/configureApplication.js
+++ b/scripts/configureApplication.js
@@ -3,8 +3,10 @@
 const fs = require('fs');
 const path = require('path');
 const childProcess = require('child_process');
+const chalk = require('chalk');
 
 const log = message => console.log(`➤ ${message}`); // eslint-disable-line no-console
+const error = message => console.log(chalk.red(`➤ ${message}`)); // eslint-disable-line no-console
 
 // TODO: fetch .env variables from Vault (or maybe just store the .env file itself in the Vault - this is painful)
 const vault = {
@@ -156,5 +158,13 @@ fs.writeFileSync(
   ),
 );
 log('Done patching RCTUtils.m');
+
+log('Checking node version');
+const version = process.versions.node;
+
+if (parseInt(version.split('.')[0], 10) < 11) {
+  // TODO: Remove this and use engines in package.json when we have upgraded node version on mobile CI
+  error('Please use node version 11.0.0 or greater for this project');
+}
 
 log('Configuration complete!');


### PR DESCRIPTION
Mobile CI runs on lower versions of node, we need to upgrade image there first.
Added a log warning in configureApplication.js for lower versions of node