### PR TITLE
Relay: Refactor QueryRenderer to use props from kiwi package

### DIFF
--- a/app/hotels/src/allHotels/HotelsPaginationContainer.js
+++ b/app/hotels/src/allHotels/HotelsPaginationContainer.js
@@ -15,11 +15,13 @@ import { withHotelsContext, type HotelsContextState } from '../HotelsContext';
 import type { CurrentSearchStats } from '../filter/CurrentSearchStatsType';
 import RenderSearchResults from './RenderSearchResults';
 import FilterStripe from '../filter/FilterStripe';
+import CloseModal from '../components/CloseModal';
 
 type PropsWithContext = {|
-  ...Props,
+  +relay: RelayPaginationProp,
   +data: ?HotelsPaginationContainerType,
   +setCurrentSearchStats: (currentSearchStats: CurrentSearchStats) => void,
+  +closeHotels: () => void,
 |};
 
 type State = {|
@@ -83,18 +85,15 @@ export class HotelsPaginationContainer extends React.Component<
           data={data}
           top={56}
         />
+        <CloseModal onPress={this.props.closeHotels} />
       </React.Fragment>
     );
   }
 }
 
-type Props = {|
-  +data: ?HotelsPaginationContainerType,
-  +relay: RelayPaginationProp,
-|};
-
-const select = ({ actions }: HotelsContextState) => ({
+const select = ({ actions, closeHotels }: HotelsContextState) => ({
   setCurrentSearchStats: actions.setCurrentSearchStats,
+  closeHotels,
 });
 
 const styles = StyleSheet.create({

--- a/app/hotels/src/allHotels/HotelsSearch.js
+++ b/app/hotels/src/allHotels/HotelsSearch.js
@@ -48,7 +48,7 @@ export default class HotelsSearch extends React.Component<Props> {
     return (
       <PublicApiRenderer
         renderOfflineScreen={this.renderOfflineScreen}
-        footer={<CloseModal onPress={this.props.onClose} />}
+        errorFooter={<CloseModal onPress={this.props.onClose} />}
         query={this.props.query}
         variables={this.props.variables}
         render={this.props.render}

--- a/app/hotels/src/map/singleHotel/SingleMap.js
+++ b/app/hotels/src/map/singleHotel/SingleMap.js
@@ -5,17 +5,26 @@ import { View } from 'react-native';
 import { graphql, createFragmentContainer } from '@kiwicom/mobile-relay';
 import { StyleSheet, StretchedImage } from '@kiwicom/mobile-shared';
 import { defaultTokens } from '@kiwicom/mobile-orbit';
+import {
+  withNavigation,
+  type NavigationType,
+} from '@kiwicom/mobile-navigation';
 
 import MapView from './MapView';
 import AdditionalInfo from './AdditionalInfo';
 import gradient from '../gradient.png';
 import type { SingleMap_hotel as HotelType } from './__generated__/SingleMap_hotel.graphql';
+import CloseModal from '../../components/CloseModal';
 
 type Props = {|
   +hotel: ?HotelType,
+  +navigation: NavigationType,
 |};
 
 const SingleMap = (props: Props) => {
+  function goBack() {
+    props.navigation.goBack();
+  }
   return (
     <View style={styles.container}>
       <MapView hotel={props.hotel?.hotel} />
@@ -25,6 +34,7 @@ const SingleMap = (props: Props) => {
       <View style={styles.dropShadow}>
         <AdditionalInfo data={props.hotel} />
       </View>
+      <CloseModal onPress={goBack} />
     </View>
   );
 };
@@ -46,7 +56,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default createFragmentContainer(SingleMap, {
+export default createFragmentContainer(withNavigation(SingleMap), {
   hotel: graphql`
     fragment SingleMap_hotel on HotelAvailabilityInterface {
       hotel {

--- a/app/hotels/src/map/singleHotel/SingleMapQueryRenderer.js
+++ b/app/hotels/src/map/singleHotel/SingleMapQueryRenderer.js
@@ -28,7 +28,7 @@ export default class SingleMapQueryRenderer extends React.Component<Props> {
         variables={this.props.variables}
         render={this.props.render}
         query={this.props.query}
-        footer={<CloseModal onPress={this.props.onClose} />}
+        errorFooter={<CloseModal onPress={this.props.onClose} />}
       />
     );
   }

--- a/app/hotels/src/singleHotel/HotelDetailScreen.js
+++ b/app/hotels/src/singleHotel/HotelDetailScreen.js
@@ -33,6 +33,7 @@ import {
   type HotelsContextState,
   type ApiProvider,
 } from '../HotelsContext';
+import BookingSummary from './summary/BookingSummary';
 
 type Price = {|
   +amount: number,
@@ -202,6 +203,7 @@ export class HotelDetailScreen extends React.Component<Props, State> {
             <BrandLabel />
           </LayoutSingleColumn>
         </ScrollView>
+        <BookingSummary goBack={this.props.goBack} />
       </View>
     );
   }

--- a/app/hotels/src/singleHotel/SingleHotelSearch.js
+++ b/app/hotels/src/singleHotel/SingleHotelSearch.js
@@ -7,7 +7,7 @@ import {
 } from '@kiwicom/mobile-relay';
 import { OfflineScreen, AdaptableLayout } from '@kiwicom/mobile-shared';
 
-import BookingSummary from './summary/BookingSummary';
+import CloseModal from '../components/CloseModal';
 
 type Props = {|
   +query: GraphQLTaggedNode,
@@ -34,7 +34,7 @@ export default class SingleHotelSearch extends React.Component<Props> {
   render() {
     return (
       <PublicApiRenderer
-        footer={<BookingSummary goBack={this.props.onClose} />}
+        errorFooter={<CloseModal onPress={this.props.onClose} />}
         renderOfflineScreen={this.renderOfflineScreen}
         query={this.props.query}
         variables={this.props.variables}

--- a/packages/relay/index.js
+++ b/packages/relay/index.js
@@ -4,6 +4,9 @@ import * as React from 'react';
 import {
   commitMutation as _commitMutation,
   type GraphQLTaggedNode as _GraphQLTaggedNode,
+  type RelayProp as _RelayProp,
+  type RefetchRelayProp,
+  type PaginationRelayProp,
 } from '@kiwicom/relay';
 import { Alert } from '@kiwicom/mobile-localization';
 
@@ -51,35 +54,11 @@ export type QueryRendererProps = {|
   +render: (props: Object) => React.Node,
   +renderOfflineScreen?: ?(retry: () => void) => React.Node,
   +variables?: Object,
-  +footer?: ?React.Node,
+  +errorFooter?: ?React.Node,
 |};
 
-export type RelayPaginationProp = {|
-  +hasMore: () => boolean,
-  +isLoading: () => boolean,
-  +loadMore: (pageSize: number, callback?: (error: ?Error) => void) => void,
-  +refetchConnection: (
-    totalCount: number,
-    callback?: (error: ?Error) => void,
-    refetchVariables: ?any,
-  ) => void,
-|};
-
-type RefetchOptions = {|
-  +force: true, // we always have to force the refetch since we use offline cache (TODO: wrap it)
-|};
-
-type Disposable = {|
-  +dispose: () => void,
-|};
-
-export type RelayRefetchProp = {|
-  +refetch: (
-    refetchVariables: Object | null | ((fragmentVariables: Object) => Object),
-    renderVariables: ?Object,
-    callback: ?(error: ?Error) => void,
-    options: RefetchOptions,
-  ) => Disposable,
-|};
+export type RelayPaginationProp = PaginationRelayProp;
+export type RelayProp = _RelayProp;
+export type RelayRefetchProp = RefetchRelayProp;
 
 export type GraphQLTaggedNode = _GraphQLTaggedNode;

--- a/packages/relay/src/PrivateApiRenderer.js
+++ b/packages/relay/src/PrivateApiRenderer.js
@@ -24,7 +24,7 @@ export function PrivateApiRenderer(props: PropsWithContext) {
       render={props.render}
       accessToken={props.accessToken}
       renderOfflineScreen={props.renderOfflineScreen}
-      footer={props.footer}
+      errorFooter={props.errorFooter}
     />
   );
 }

--- a/packages/relay/src/PublicApiRenderer.js
+++ b/packages/relay/src/PublicApiRenderer.js
@@ -12,7 +12,7 @@ export default function PublicApiRenderer(props: QueryRendererProps) {
       variables={props.variables}
       render={props.render}
       renderOfflineScreen={props.renderOfflineScreen}
-      footer={props.footer}
+      errorFooter={props.errorFooter}
     />
   );
 }

--- a/packages/relay/src/__tests__/QueryRenderer.test.js
+++ b/packages/relay/src/__tests__/QueryRenderer.test.js
@@ -22,7 +22,7 @@ describe('QueryRenderer', () => {
     const QR = new QueryRenderer({});
     expect(
       QR.renderRelayContainer({
-        error: new TypeError('Network request failed'),
+        error: new Error('Network request failed'),
         retry,
       }),
     ).toMatchSnapshot();
@@ -32,15 +32,8 @@ describe('QueryRenderer', () => {
     // $FlowExpectedError: Don't need all props for this test
     const QR = new QueryRenderer({});
     expect(
-      QR.renderRelayContainer({ error: new Error('custom message'), retry }),
-    ).toMatchSnapshot();
-  });
-
-  it('returns loader if no props and no errors', () => {
-    // $FlowExpectedError: Don't need all props for this test
-    const QR = new QueryRenderer({});
-    expect(
       QR.renderRelayContainer({
+        error: new Error('custom message'),
         retry,
       }),
     ).toMatchSnapshot();
@@ -52,7 +45,7 @@ describe('QueryRenderer', () => {
     // $FlowExpectedError: Don't need all props for this test
     const QR = new QueryRenderer({ renderOfflineScreen });
     QR.renderRelayContainer({
-      error: new TypeError('Network request failed'),
+      error: new Error('Network request failed'),
       retry,
     });
     expect(renderOfflineScreen).toHaveBeenCalledWith(retry);
@@ -62,9 +55,10 @@ describe('QueryRenderer', () => {
     const Footer = () => 'test';
 
     // $FlowExpectedError: Don't need all props for this test
-    const QR = new QueryRenderer({ footer: <Footer /> });
+    const QR = new QueryRenderer({ errorFooter: <Footer /> });
     expect(
       QR.renderRelayContainer({
+        error: new Error('LOL'),
         retry,
       }),
     ).toMatchSnapshot();

--- a/packages/relay/src/__tests__/__snapshots__/QueryRenderer.test.js.snap
+++ b/packages/relay/src/__tests__/__snapshots__/QueryRenderer.test.js.snap
@@ -2,7 +2,13 @@
 
 exports[`QueryRenderer renders footerComponent if passed 1`] = `
 <React.Fragment>
-  <FullPageLoading />
+  <GeneralError
+    errorMessage={
+      <Translation
+        passThrough="LOL"
+      />
+    }
+  />
   <Footer />
 </React.Fragment>
 `;
@@ -28,11 +34,5 @@ exports[`QueryRenderer returns general error for other errors 1`] = `
       />
     }
   />
-</React.Fragment>
-`;
-
-exports[`QueryRenderer returns loader if no props and no errors 1`] = `
-<React.Fragment>
-  <FullPageLoading />
 </React.Fragment>
 `;


### PR DESCRIPTION
Replace footer with errorFooter.
Reconnect close modal components where they belong in component tree.