### PR TITLE
Relay: Allow changing the authorization header key

### DIFF
--- a/packages/relay/src/Environment.js
+++ b/packages/relay/src/Environment.js
@@ -111,7 +111,10 @@ const asyncStoreRead = async (observer, operation, variables) => {
   }
 };
 
-export default function createEnvironment(accessToken: string = '') {
+export default function createEnvironment(
+  accessToken: string = '',
+  authHeaderKey: string = 'authorization',
+) {
   const networkHeaders: Object = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
@@ -119,7 +122,7 @@ export default function createEnvironment(accessToken: string = '') {
   };
 
   if (accessToken) {
-    networkHeaders.authorization = accessToken;
+    networkHeaders[authHeaderKey] = accessToken;
   }
 
   const fetchQuery = (operation, variables): Promise<FetcherResponse> => {

--- a/packages/relay/src/PrivateApiRenderer.js
+++ b/packages/relay/src/PrivateApiRenderer.js
@@ -9,6 +9,7 @@ import AuthContext from './AuthContext';
 type PropsWithContext = {|
   ...QueryRendererProps,
   +accessToken: string | null,
+  +authHeaderKey?: string,
 |};
 
 export function PrivateApiRenderer(props: PropsWithContext) {
@@ -23,6 +24,7 @@ export function PrivateApiRenderer(props: PropsWithContext) {
       variables={props.variables}
       render={props.render}
       accessToken={props.accessToken}
+      authHeaderKey={props.authHeaderKey}
       renderOfflineScreen={props.renderOfflineScreen}
       errorFooter={props.errorFooter}
     />

--- a/packages/relay/src/PrivateEnvironment.js
+++ b/packages/relay/src/PrivateEnvironment.js
@@ -6,13 +6,13 @@ export default new class PrivateEnvironment {
   environment = null;
   token = null;
 
-  getEnvironment = (token: string) => {
+  getEnvironment = (token: string, headerKey?: string) => {
     if (!token) {
       throw new Error('Cannot create private environment without token.');
     }
 
     if (this.environment === null || token !== this.token) {
-      this.environment = createEnvironment(token);
+      this.environment = createEnvironment(token, headerKey);
     }
 
     this.token = token;

--- a/packages/relay/src/QueryRenderer.js
+++ b/packages/relay/src/QueryRenderer.js
@@ -16,6 +16,7 @@ import type { QueryRendererProps } from '../index';
 type Props = {|
   ...QueryRendererProps,
   +accessToken?: string,
+  +authHeaderKey?: string,
 |};
 
 type RendererResponse = {
@@ -35,7 +36,10 @@ export default class QueryRenderer extends React.Component<Props> {
       return PublicEnvironment.getEnvironment();
     }
 
-    return PrivateEnvironment.getEnvironment(accessToken);
+    return PrivateEnvironment.getEnvironment(
+      accessToken,
+      this.props.authHeaderKey,
+    );
   };
 
   renderRelayContainer = ({ error, retry }: RendererResponse) => {

--- a/packages/relay/src/__tests__/QueryRenderer.test.js
+++ b/packages/relay/src/__tests__/QueryRenderer.test.js
@@ -87,6 +87,22 @@ describe('QueryRenderer', () => {
     // $FlowExpectedError: Don't need to pass all props for this test
     const Component = new QueryRenderer({ accessToken: 'token' });
     Component.createEnvironment();
-    expect(PrivateEnvironment.getEnvironment).toHaveBeenCalledWith('token');
+    expect(PrivateEnvironment.getEnvironment).toHaveBeenCalledWith(
+      'token',
+      undefined,
+    );
+  });
+
+  it('calls PrivateEnvironment.getEnvironment with authHeaderKey if passed', () => {
+    // $FlowExpectedError: Don't need to pass all props for this test
+    const Component = new QueryRenderer({
+      accessToken: 'token',
+      authHeaderKey: 'kw-test',
+    });
+    Component.createEnvironment();
+    expect(PrivateEnvironment.getEnvironment).toHaveBeenCalledWith(
+      'token',
+      'kw-test',
+    );
   });
 });


### PR DESCRIPTION
We have different header keys for authorization, so we need to be able
to change this header value based on which query we are calling