### PR TITLE
Remove usage of dimensions passed from native iOS app

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,18 +1,14 @@
 // @flow
 
 import React from 'react';
-import { type DimensionType, Dimensions } from '@kiwicom/mobile-shared';
+import { Dimensions } from '@kiwicom/mobile-shared';
 
 import Navigation from './core/src/navigation';
 import HotelsContextForm from './core/src/screens/hotelsStack/HotelsFormContext';
 
-type initialProps = {|
-  +dimensions: DimensionType,
-|};
-
-export default function App(props: initialProps) {
+export default function App() {
   return (
-    <Dimensions.Provider dimensions={props.dimensions}>
+    <Dimensions.Provider>
       <HotelsContextForm>
         <Navigation />
       </HotelsContextForm>

--- a/app/hotels/src/appRegistry/NewHotelsStandalonePackage.js
+++ b/app/hotels/src/appRegistry/NewHotelsStandalonePackage.js
@@ -1,11 +1,7 @@
 // @flow strict
 
 import * as React from 'react';
-import {
-  WithNativeNavigation,
-  type DimensionType,
-  AdaptableLayout,
-} from '@kiwicom/mobile-shared';
+import { WithNativeNavigation, AdaptableLayout } from '@kiwicom/mobile-shared';
 
 import RootComponent from './RootComponent';
 import HotelsStack from '../navigation/HotelsNavigationStack';
@@ -23,7 +19,6 @@ type Props = {
   +onNavigationStateChange: () => void,
   +onBackClicked: () => void,
   +lastNavigationMode?: string,
-  +dimensions: DimensionType,
   +version: string,
   +cityName: string,
   +cityId: string,
@@ -43,7 +38,6 @@ class NewHotelsStandalonePackage extends React.Component<Props> {
     };
     return (
       <RootComponent
-        dimensions={this.props.dimensions}
         dataSaverEnabled={this.props.dataSaverEnabled}
         version={this.props.version}
         cityId={this.props.cityId}

--- a/app/hotels/src/appRegistry/RootComponent.js
+++ b/app/hotels/src/appRegistry/RootComponent.js
@@ -2,11 +2,7 @@
 
 import * as React from 'react';
 import { ConfigContext } from '@kiwicom/mobile-config';
-import {
-  Dimensions,
-  type DimensionType,
-  GestureController,
-} from '@kiwicom/mobile-shared';
+import { Dimensions, GestureController } from '@kiwicom/mobile-shared';
 
 import HotelsFilterContext from '../HotelsFilterContext';
 import HotelsContext, {
@@ -19,7 +15,6 @@ import type { Coordinates } from '../CoordinatesType';
 type Props = {|
   +dataSaverEnabled: boolean,
   +children: React.Node,
-  +dimensions: DimensionType,
   +version: string,
   +cityId?: string,
   +cityName?: string,
@@ -76,9 +71,7 @@ export default class RootComponent extends React.Component<Props> {
               closeHotels={this.onClosePress}
               guestCount={guestCount}
             >
-              <Dimensions.Provider dimensions={this.props.dimensions}>
-                {this.props.children}
-              </Dimensions.Provider>
+              <Dimensions.Provider>{this.props.children}</Dimensions.Provider>
             </HotelsContext.Provider>
           </HotelsFilterContext.Provider>
         </ConfigContext.Provider>

--- a/app/hotels/src/appRegistry/SingleHotelStandalonePackage.js
+++ b/app/hotels/src/appRegistry/SingleHotelStandalonePackage.js
@@ -1,10 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import {
-  WithNativeNavigation,
-  type DimensionType,
-} from '@kiwicom/mobile-shared';
+import { WithNativeNavigation } from '@kiwicom/mobile-shared';
 
 import RootComponent from './RootComponent';
 import SingleHotelStack from '../navigation/singleHotel/SingleHotelStack';
@@ -20,7 +17,6 @@ type Props = {
   +language: string,
   +onNavigationStateChange: () => void,
   +onBackClicked: () => void,
-  +dimensions: DimensionType,
   +version: string,
   +lastNavigationMode?: string,
 };
@@ -37,7 +33,6 @@ class SingleHotelStandAlonePackage extends React.Component<Props> {
     };
     return (
       <RootComponent
-        dimensions={this.props.dimensions}
         dataSaverEnabled={this.props.dataSaverEnabled}
         version={this.props.version}
         currency={this.props.currency}

--- a/ios/RNNativePlayground/ViewController.m
+++ b/ios/RNNativePlayground/ViewController.m
@@ -223,14 +223,6 @@
   return [dataArray objectAtIndex:[cityPicker selectedRowInComponent:0]];
 }
 
-- (NSDictionary *)windowDimensions {
-  CGRect windowRect = self.view.window.frame;
-  return @{
-           @"width": @(windowRect.size.width),
-           @"height": @(windowRect.size.height)
-         };
-}
-
 
 
 - (void)setActiveViewController:(RNKiwiViewController *)vc {
@@ -251,7 +243,6 @@
                                                           @"language": @"en",
                                                           @"currency": @"EUR",
                                                           @"lastNavigationMode": @"present",
-                                                          @"dimensions": [self windowDimensions],
                                                           @"checkin": [self selectedStartDate],
                                                           @"checkout": [self selectedEndDate],
                                                           @"version": @"3.7.13-9d55ad66",
@@ -281,7 +272,6 @@
                                                                             @"language": @"en",
                                                                             @"currency": @"EUR",
                                                                             @"lastNavigationMode": @"present",
-                                                                            @"dimensions": [self windowDimensions],
                                                                             @"checkin": [self selectedStartDate],
                                                                             @"checkout": [self selectedEndDate],
                                                                             @"version": @"3.7.13-9d55ad66",

--- a/packages/playground/src/Playground.js
+++ b/packages/playground/src/Playground.js
@@ -63,7 +63,7 @@ export default class Playground extends React.Component<Props> {
       );
     }
     return (
-      <Dimensions.Provider dimensions={this.props.dimensions}>
+      <Dimensions.Provider>
         <ScrollView>
           {PlaygroundRenderer.components[this.props.name].components.map(
             (component, index) => {

--- a/packages/shared/src/popup/__tests__/ButtonPopup.test.js
+++ b/packages/shared/src/popup/__tests__/ButtonPopup.test.js
@@ -9,9 +9,13 @@ import Touchable from '../../Touchable';
 import Dimensions from '../../view/Dimensions';
 import CloseButton from '../../buttons/CloseButton';
 
+jest.mock('Dimensions', () => ({
+  get: () => ({ width: 500, height: 500 }),
+}));
+
 const renderPopup = (onSave, onClose) =>
   renderer.create(
-    <Dimensions.Provider dimensions={{ width: 500, height: 700 }}>
+    <Dimensions.Provider>
       <ButtonPopup
         buttonTitle={<Translation passThrough="Save" />}
         isVisible={true}

--- a/packages/shared/src/view/DimensionsConsumer.js
+++ b/packages/shared/src/view/DimensionsConsumer.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from 'react';
-import { Dimensions } from 'react-native';
 
 import { type DimensionType } from '../../types/Objects';
 import Context from './DimensionsContext';
@@ -22,17 +21,7 @@ export function withDimensions<PassedProps: {}>(
     $Diff<PassedProps, InjectedProps>,
   > {
     renderInner = ({ dimensions }) => {
-      let height;
-      let width;
-      if (dimensions == null) {
-        const window = Dimensions.get('window');
-        height = window.height;
-        width = window.width;
-      } else {
-        height = dimensions.height;
-        width = dimensions.width;
-      }
-      return <Component {...this.props} height={height} width={width} />;
+      return <Component {...this.props} {...dimensions} />;
     };
 
     render() {
@@ -41,23 +30,8 @@ export function withDimensions<PassedProps: {}>(
   };
 }
 
-export default class DimensionsConsumer extends React.Component<Props> {
-  render() {
-    return (
-      <Context.Consumer>
-        {({ dimensions }) => {
-          if (dimensions == null) {
-            // Dimensions on Android are fine from Dimensions module
-            // so we do not to explicit pass them on a native app
-            const { height, width } = Dimensions.get('window');
-            return this.props.children({
-              width,
-              height,
-            });
-          }
-          return this.props.children(dimensions);
-        }}
-      </Context.Consumer>
-    );
-  }
+export default function DimensionsConsumer(props: Props) {
+  const { dimensions } = React.useContext(Context);
+
+  return props.children({ height: dimensions.height, width: dimensions.width });
 }

--- a/packages/shared/src/view/DimensionsContext.js
+++ b/packages/shared/src/view/DimensionsContext.js
@@ -1,13 +1,17 @@
 // @flow
 
 import * as React from 'react';
+import { Dimensions } from 'react-native';
 
 import type { DimensionType } from '../../index';
 
 type ContextType = {|
-  +dimensions: ?DimensionType,
+  +dimensions: DimensionType,
 |};
 
+const window = Dimensions.get('window');
+const height = window.height;
+const width = window.width;
 export default React.createContext<ContextType>({
-  dimensions: null,
+  dimensions: { width, height },
 });

--- a/packages/shared/src/view/DimensionsProvider.js
+++ b/packages/shared/src/view/DimensionsProvider.js
@@ -1,25 +1,36 @@
 // @flow
 
 import * as React from 'react';
-import { View } from 'react-native';
+import { View, Dimensions } from 'react-native';
 
 import Context from './DimensionsContext';
 import StyleSheet from '../PlatformStyleSheet';
-import type { OnLayout, DimensionType } from '../../index';
+import type { OnLayout } from '../../types/Events';
+import type { DimensionType } from '../../types/Objects';
 
 type Props = {|
   +children: React.Node,
-  +dimensions: ?DimensionType,
 |};
 
 type State = {|
-  dimensions: ?DimensionType,
+  dimensions: DimensionType,
 |};
 
 class DimensionsProvider extends React.Component<Props, State> {
-  state = {
-    dimensions: this.props.dimensions,
-  };
+  constructor(props: Props) {
+    super(props);
+
+    const window = Dimensions.get('window');
+    const height = window.height;
+    const width = window.width;
+
+    this.state = {
+      dimensions: {
+        height,
+        width,
+      },
+    };
+  }
 
   onLayout = (event: OnLayout) => {
     const { width, height } = event.nativeEvent.layout;

--- a/packages/shared/src/view/__tests__/AdaptableLayout.narrow.test.js
+++ b/packages/shared/src/view/__tests__/AdaptableLayout.narrow.test.js
@@ -9,6 +9,15 @@ import AdaptableLayout from '../AdaptableLayout';
 jest.mock('../../Device', () => ({
   isWideLayout: () => false,
 }));
+let width = 700;
+
+jest.doMock('Dimensions', () => ({
+  get: () => ({ width, height: 500 }),
+}));
+
+afterEach(() => {
+  width = 700;
+});
 
 const RendersCorrectly = () => 'I am going to render without any problems...';
 
@@ -17,9 +26,10 @@ const ThrowsError = () => {
 };
 
 it('renders narrow components', () => {
+  width = 200;
   expect(
     Renderer.create(
-      <Dimensions.Provider dimensions={{ width: 200, height: 500 }}>
+      <Dimensions.Provider>
         <AdaptableLayout
           renderOnWide={<ThrowsError />}
           renderOnNarrow={<RendersCorrectly />}
@@ -32,7 +42,7 @@ it('renders narrow components', () => {
 it('renders empty element if there is no narrow layout', () => {
   expect(
     Renderer.create(
-      <Dimensions.Provider dimensions={{ width: 700, height: 500 }}>
+      <Dimensions.Provider>
         <AdaptableLayout renderOnWide={<ThrowsError />} />
       </Dimensions.Provider>,
     ),

--- a/packages/shared/src/view/__tests__/AdaptableLayout.test.js
+++ b/packages/shared/src/view/__tests__/AdaptableLayout.test.js
@@ -9,7 +9,7 @@ import Dimensions from '../Dimensions';
 it('renders empty element without props', () => {
   expect(
     Renderer.create(
-      <Dimensions.Provider dimensions={null}>
+      <Dimensions.Provider>
         <AdaptableLayout />
       </Dimensions.Provider>,
     ),

--- a/packages/shared/src/view/__tests__/AdaptableLayout.wide.test.js
+++ b/packages/shared/src/view/__tests__/AdaptableLayout.wide.test.js
@@ -10,6 +10,16 @@ jest.mock('../../Device', () => ({
   isWideLayout: () => true,
 }));
 
+let width = 700;
+
+jest.doMock('Dimensions', () => ({
+  get: () => ({ width, height: 500 }),
+}));
+
+afterEach(() => {
+  width = 700;
+});
+
 const RendersCorrectly = () => 'I am going to render without any problems...';
 const ThrowsError = () => {
   throw new Error('do not render');
@@ -18,7 +28,7 @@ const ThrowsError = () => {
 it('renders wide components', () => {
   expect(
     Renderer.create(
-      <Dimensions.Provider dimensions={{ width: 700, height: 500 }}>
+      <Dimensions.Provider>
         <AdaptableLayout
           renderOnNarrow={<ThrowsError />}
           renderOnWide={<RendersCorrectly />}
@@ -29,9 +39,10 @@ it('renders wide components', () => {
 });
 
 it('renders empty element if there is no wide layout', () => {
+  width = 200;
   expect(
     Renderer.create(
-      <Dimensions.Provider dimensions={{ width: 200, height: 500 }}>
+      <Dimensions.Provider>
         <AdaptableLayout renderOnNarrow={<ThrowsError />} />
       </Dimensions.Provider>,
     ),

--- a/packages/shared/src/view/__tests__/__snapshots__/AdaptableLayout.narrow.test.js.snap
+++ b/packages/shared/src/view/__tests__/__snapshots__/AdaptableLayout.narrow.test.js.snap
@@ -1,25 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders empty element if there is no narrow layout 1`] = `
-<View
-  onLayout={[Function]}
-  style={
-    Object {
-      "flex": 1,
-    }
-  }
-/>
-`;
+exports[`renders empty element if there is no narrow layout 1`] = `null`;
 
-exports[`renders narrow components 1`] = `
-<View
-  onLayout={[Function]}
-  style={
-    Object {
-      "flex": 1,
-    }
-  }
->
-  I am going to render without any problems...
-</View>
-`;
+exports[`renders narrow components 1`] = `"I am going to render without any problems..."`;

--- a/packages/shared/src/view/__tests__/__snapshots__/AdaptableLayout.test.js.snap
+++ b/packages/shared/src/view/__tests__/__snapshots__/AdaptableLayout.test.js.snap
@@ -1,12 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders empty element without props 1`] = `
-<View
-  onLayout={[Function]}
-  style={
-    Object {
-      "flex": 1,
-    }
-  }
-/>
-`;
+exports[`renders empty element without props 1`] = `null`;

--- a/packages/shared/src/view/__tests__/__snapshots__/AdaptableLayout.wide.test.js.snap
+++ b/packages/shared/src/view/__tests__/__snapshots__/AdaptableLayout.wide.test.js.snap
@@ -1,25 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders empty element if there is no wide layout 1`] = `
-<View
-  onLayout={[Function]}
-  style={
-    Object {
-      "flex": 1,
-    }
-  }
-/>
-`;
+exports[`renders empty element if there is no wide layout 1`] = `null`;
 
-exports[`renders wide components 1`] = `
-<View
-  onLayout={[Function]}
-  style={
-    Object {
-      "flex": 1,
-    }
-  }
->
-  I am going to render without any problems...
-</View>
-`;
+exports[`renders wide components 1`] = `"I am going to render without any problems..."`;


### PR DESCRIPTION
These dimensions was not used anyway. They were put into the context
then overwritten by the onLayout function triggering when the app started up

closes #1567 