### PR TITLE
mobile-relay: Fixed props for PrivateApiRenderer

### DIFF
--- a/packages/relay/src/PrivateApiRenderer.js
+++ b/packages/relay/src/PrivateApiRenderer.js
@@ -8,7 +8,7 @@ import AuthContext from './AuthContext';
 
 type PropsWithContext = {|
   ...QueryRendererProps,
-  +accessToken: string | null,
+  +accessToken?: string | null,
   +authHeaderKey?: string,
 |};
 
@@ -31,9 +31,7 @@ export function PrivateApiRenderer(props: PropsWithContext) {
   );
 }
 
-export default function PrivateApiRendererWithContext(
-  props: QueryRendererProps,
-) {
+export default function PrivateApiRendererWithContext(props: PropsWithContext) {
   return (
     <AuthContext.Consumer>
       {({ accessToken }) => (

--- a/packages/relay/src/PrivateApiRenderer.js
+++ b/packages/relay/src/PrivateApiRenderer.js
@@ -7,9 +7,8 @@ import type { QueryRendererProps } from '../index';
 import AuthContext from './AuthContext';
 
 type PropsWithContext = {|
-  ...QueryRendererProps,
-  +accessToken?: string | null,
-  +authHeaderKey?: string,
+  ...Props,
+  +accessToken: string | null,
 |};
 
 export function PrivateApiRenderer(props: PropsWithContext) {
@@ -31,7 +30,12 @@ export function PrivateApiRenderer(props: PropsWithContext) {
   );
 }
 
-export default function PrivateApiRendererWithContext(props: PropsWithContext) {
+type Props = {|
+  ...QueryRendererProps,
+  +authHeaderKey?: string,
+|};
+
+export default function PrivateApiRendererWithContext(props: Props) {
   return (
     <AuthContext.Consumer>
       {({ accessToken }) => (


### PR DESCRIPTION
**PrivateApiRendererWithContext** as default export should take **authHeaderKey** as a prop and forward it to **PrivateApiRenderer** and _accessToken_ is optional since it is taken from context and not provided via props.