### PR TITLE
Ancillaries: Added AncillaryViewController for integrating ancillaries

### DIFF
--- a/ios/RNKiwiMobile/AncillaryViewController.h
+++ b/ios/RNKiwiMobile/AncillaryViewController.h
@@ -1,0 +1,20 @@
+//
+//  AncillaryViewController.h
+//  RNKiwiMobile
+//
+//  Copyright © 2019 Kiwi. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "RNKiwiCurrencyManager.h"
+#import "RNKiwiTranslationProvider.h"
+
+@interface AncillaryViewController : UIViewController
+
+- (nonnull instancetype)init:(NSString *)serviceName bookingId:(NSNumber *)bookingId kwAuthToken:(NSString *)kwAuthToken;
+
+// Delegates
+@property(nonatomic, weak, nullable) id<RNKiwiCurrencyManager> currencyFormatter;
+@property(nonatomic, weak, nullable) id<RNKiwiTranslationProvider> translationProvider;
+
+@end

--- a/ios/RNKiwiMobile/AncillaryViewController.m
+++ b/ios/RNKiwiMobile/AncillaryViewController.m
@@ -1,0 +1,57 @@
+//
+//  AncillaryViewController.m
+//  RNKiwiMobile
+//
+//  Copyright © 2019 Kiwi. All rights reserved.
+//
+
+#import "AncillaryViewController.h"
+#import "RNKiwiSharedBridge.h"
+
+#import <RNModules/RNLoggingModule.h>
+#import <RNModules/RNTranslationManager.h>
+#import <RNModules/RNCurrencyManager.h>
+#import <RNModules/RNDeviceInfo.h>
+
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+@interface AncillaryViewController() <RNLogger, RNTranslator, RNCurrencyFormatter>
+
+@property (nonatomic, strong) NSString* serviceName;
+@property (nonatomic, strong) NSNumber* bookingId;
+@property (nonatomic, strong) NSString* kwAuthToken;
+
+@end
+
+@implementation AncillaryViewController
+
+- (instancetype)init:(NSString *)service bookingId:(NSNumber *)bookingId kwAuthToken:(NSString *)kwAuthToken{
+  self = [super init];
+  
+  if (self) {
+    _serviceName = service;
+    _bookingId = bookingId;
+    _kwAuthToken = kwAuthToken;
+    
+    [self setupReactWrappersWithObject:self];
+    [self loadView];
+  }
+  
+  return self;
+}
+
+- (void)setupReactWrappersWithObject:(id)object {
+  [RNLoggingModule setLogger:object];
+  [RNTranslationManager setTranslator:object];
+  [RNCurrencyManager setCurrencyFormatter:object];
+}
+
+- (void)loadView {
+  
+  self.view = [[RCTRootView alloc] initWithBridge:[[RNKiwiSharedBridge sharedInstance] bridge]
+                                       moduleName: @"AncillaryFactory"
+                                initialProperties: @{@"service": _serviceName, @"bookingId": _bookingId, @"kwAuthToken": _kwAuthToken}];
+}
+
+@end

--- a/ios/RNKiwiMobile/RNKiwiMobile.h
+++ b/ios/RNKiwiMobile/RNKiwiMobile.h
@@ -13,3 +13,4 @@ FOUNDATION_EXPORT const unsigned char RNKiwiMobileVersionString[];
 #import "RNKiwiCurrencyManager.h"
 #import "RNKiwiSharedBridge.h"
 #import "RNKiwiConstants.h"
+#import "AncillaryViewController.h"

--- a/ios/reactNativeApp.xcodeproj/project.pbxproj
+++ b/ios/reactNativeApp.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };

--- a/ios/reactNativeApp.xcodeproj/project.pbxproj
+++ b/ios/reactNativeApp.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
@@ -44,6 +45,8 @@
 		68E80E25215E66CD00EB4717 /* CircularPro-Book.otf in Resources */ = {isa = PBXBuildFile; fileRef = A6319717E9F64AE8AFA770C0 /* CircularPro-Book.otf */; };
 		6AC23FDF8E5142199F66BC24 /* CircularPro-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 71A4A2C5C6994635AF8475F2 /* CircularPro-Bold.otf */; };
 		898C440300784E69B91D0ED6 /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 2D1E4633998A4228B3B7F222 /* Roboto-Medium.ttf */; };
+		9399D42C226F18B6005C0F67 /* AncillaryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9399D42A226F18B6005C0F67 /* AncillaryViewController.m */; };
+		9399D42D226F18B6005C0F67 /* AncillaryViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9399D42B226F18B6005C0F67 /* AncillaryViewController.h */; };
 		AE942438053B4672A7E086F8 /* orbit-icons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A7DB7617FCB64964BEDA22CA /* orbit-icons.ttf */; };
 		DD9F4DDDD70840CBBECA0434 /* CircularPro-Book.otf in Resources */ = {isa = PBXBuildFile; fileRef = A6319717E9F64AE8AFA770C0 /* CircularPro-Book.otf */; };
 		F42D2DA1998548F1808065BE /* Roboto-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5EF541A9996B4D6AB8AEDA5B /* Roboto-Bold.ttf */; };
@@ -141,6 +144,8 @@
 		71A4A2C5C6994635AF8475F2 /* CircularPro-Bold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "CircularPro-Bold.otf"; path = "../assets/fonts/ios/CircularPro-Bold.otf"; sourceTree = "<group>"; };
 		7362EE36714587FAF8D16632 /* Pods-RNKiwiMobile.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNKiwiMobile.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNKiwiMobile/Pods-RNKiwiMobile.debug.xcconfig"; sourceTree = "<group>"; };
 		83DEB0A076A11B421C735EE9 /* Pods-RNPlayground.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNPlayground.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNPlayground/Pods-RNPlayground.debug.xcconfig"; sourceTree = "<group>"; };
+		9399D42A226F18B6005C0F67 /* AncillaryViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AncillaryViewController.m; sourceTree = "<group>"; };
+		9399D42B226F18B6005C0F67 /* AncillaryViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AncillaryViewController.h; sourceTree = "<group>"; };
 		A42E4EC96B6B81F2DFC8C869 /* libPods-RNPlayground.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNPlayground.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6319717E9F64AE8AFA770C0 /* CircularPro-Book.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "CircularPro-Book.otf"; path = "../assets/fonts/ios/CircularPro-Book.otf"; sourceTree = "<group>"; };
 		A7DB7617FCB64964BEDA22CA /* orbit-icons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "orbit-icons.ttf"; path = "../assets/fonts/orbit-icons.ttf"; sourceTree = "<group>"; };
@@ -217,6 +222,8 @@
 		27E931B120AD96790053AE19 /* RNKiwiMobile */ = {
 			isa = PBXGroup;
 			children = (
+				9399D42B226F18B6005C0F67 /* AncillaryViewController.h */,
+				9399D42A226F18B6005C0F67 /* AncillaryViewController.m */,
 				27E931B220AD96790053AE19 /* RNKiwiMobile.h */,
 				686E004A20B2E1360013512F /* RNKiwiConstants.h */,
 				686E005020B2E24B0013512F /* RNKiwiConstants.m */,
@@ -332,6 +339,7 @@
 				27E931C520AD9A4B0053AE19 /* RNKiwiCurrencyManager.h in Headers */,
 				2711986F20B2A0C100C6292B /* RNKiwiSharedBridge.h in Headers */,
 				686E004B20B2E1360013512F /* RNKiwiConstants.h in Headers */,
+				9399D42D226F18B6005C0F67 /* AncillaryViewController.h in Headers */,
 				27E931B420AD96790053AE19 /* RNKiwiMobile.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -434,6 +442,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -596,6 +605,7 @@
 				2711987020B2A0C100C6292B /* RNKiwiSharedBridge.m in Sources */,
 				686E005120B2E24B0013512F /* RNKiwiConstants.m in Sources */,
 				2107154620B5677200E6C96B /* RNKiwiGestureController.m in Sources */,
+				9399D42C226F18B6005C0F67 /* AncillaryViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/reactNativeApp.xcodeproj/project.pbxproj
+++ b/ios/reactNativeApp.xcodeproj/project.pbxproj
@@ -46,7 +46,7 @@
 		6AC23FDF8E5142199F66BC24 /* CircularPro-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 71A4A2C5C6994635AF8475F2 /* CircularPro-Bold.otf */; };
 		898C440300784E69B91D0ED6 /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 2D1E4633998A4228B3B7F222 /* Roboto-Medium.ttf */; };
 		9399D42C226F18B6005C0F67 /* AncillaryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9399D42A226F18B6005C0F67 /* AncillaryViewController.m */; };
-		9399D42D226F18B6005C0F67 /* AncillaryViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9399D42B226F18B6005C0F67 /* AncillaryViewController.h */; };
+		9399D42D226F18B6005C0F67 /* AncillaryViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9399D42B226F18B6005C0F67 /* AncillaryViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AE942438053B4672A7E086F8 /* orbit-icons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A7DB7617FCB64964BEDA22CA /* orbit-icons.ttf */; };
 		DD9F4DDDD70840CBBECA0434 /* CircularPro-Book.otf in Resources */ = {isa = PBXBuildFile; fileRef = A6319717E9F64AE8AFA770C0 /* CircularPro-Book.otf */; };
 		F42D2DA1998548F1808065BE /* Roboto-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5EF541A9996B4D6AB8AEDA5B /* Roboto-Bold.ttf */; };


### PR DESCRIPTION
This is remaining code for fast track ancillary.
iOS team wanted to have a clear view controller for ancillaries integration, that's why it doesn't have `RNKiwi` prefix.


