### PR TITLE
Android: Change RNKiwiActivity to extend FragmentActivity

### DIFF
--- a/.build/package.json
+++ b/.build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiwicom/react-native-app-hotels",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "private": false,
   "main": "index.js",
   "dependencies": {

--- a/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/RNKiwiActivity.kt
+++ b/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/RNKiwiActivity.kt
@@ -1,9 +1,9 @@
 package com.kiwi.rnkiwimobile
 
 import android.annotation.TargetApi
-import android.app.Activity
 import android.os.Build
 import android.os.Bundle
+import android.support.v7.app.AppCompatActivity;
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactRootView
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
@@ -11,7 +11,7 @@ import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 
 abstract class RNKiwiActivity(private val initialProperties: Bundle?) :
-  Activity(),
+  AppCompatActivity(),
   DefaultHardwareBackBtnHandler, PermissionAwareActivity {
 
   // region Private Properties

--- a/docs/common/changelog.md
+++ b/docs/common/changelog.md
@@ -7,7 +7,7 @@ this will be evened out from v24
 
 ## Target version 10.0.0
 
-- Upgrade rnkiwimobile to version `0.0.45`
+- Upgrade rnkiwimobile to version `0.0.46`
 
 ### v35
 - Replace decimal.js with ligher decimal.js-light


### PR DESCRIPTION
React-Native has changed DatePickerDialogModule to only support FragmentActivity
https://github.com/facebook/react-native/pull/23371