### PR TITLE
Hotels: FIX height of separator in StarsPopup

### DIFF
--- a/app/hotels/src/filter/stars/StarsPopup.js
+++ b/app/hotels/src/filter/stars/StarsPopup.js
@@ -67,7 +67,7 @@ export default class StarsPopup extends React.Component<Props, State> {
             <SeparatorTrimmed
               gapSizeStart={0}
               color={defaultTokens.paletteInkLighter}
-              height={0.5}
+              height={StyleSheet.hairlineWidth}
             />
           </View>
         </React.Fragment>,


### PR DESCRIPTION
This fixes MOBILE-4112.

This was also not rendered correctly on iOS: some separators would be rendered with bigger height than others. My interpretation of this issue is that `0.5` is not consistently rendered on different screens with different screen densities. Using `StyleSheet.hairlineWidth` fixes this issue as it's optimised to always be a round number of pixels
> This constant will always be a round number of pixels (so a line defined by it can look crisp) and will try to match the standard width of a thin line on the underlying platform

https://facebook.github.io/react-native/docs/stylesheet#hairlinewidth