### PR TITLE
Hotels: SummaryRow should use dynamic width to truncate text

### DIFF
--- a/app/hotels/src/singleHotel/summary/SummaryRow.js
+++ b/app/hotels/src/singleHotel/summary/SummaryRow.js
@@ -6,7 +6,6 @@ import {
   Price,
   Text,
   type OnLayout,
-  withDimensions,
   Translation,
 } from '@kiwicom/mobile-shared';
 import { View } from 'react-native';
@@ -15,49 +14,38 @@ import { defaultTokens } from '@kiwicom/mobile-orbit';
 type Props = {|
   +text: React.Element<typeof Translation>,
   +price: React.Element<typeof Price>,
-  +width: number,
 |};
 
-type State = {|
-  +maxTextWidth: number | null,
-|};
+const SPACING = 5;
 
-class SummaryRow extends React.Component<Props, State> {
-  state = {
-    maxTextWidth: null,
-  };
+const SummaryRow = ({ text, price }: Props) => {
+  const [containerWidth, setContainerWidth] = React.useState(null);
+  const [priceWidth, setPriceWidth] = React.useState(null);
 
-  onLayout = (event: OnLayout) => {
-    const pagePadding = 34;
-    const spacing = 5;
-    // Text does not play well with price when it grows too long.
-    // Wee need to calculate maxWidth for the text, unless it will push
-    // Price out of the screen
-    this.setState({
-      maxTextWidth:
-        this.props.width -
-        event.nativeEvent.layout.width -
-        pagePadding -
-        spacing,
-    });
-  };
-
-  render() {
-    return (
-      <View style={styles.row}>
-        <Text
-          style={[styles.text, { maxWidth: this.state.maxTextWidth }]}
-          numberOfLines={1}
-        >
-          {this.props.text}
-        </Text>
-        <View onLayout={this.onLayout}>
-          <Text style={styles.price}>{this.props.price}</Text>
-        </View>
-      </View>
-    );
+  function onContainerLayout(event: OnLayout) {
+    setContainerWidth(event.nativeEvent.layout.width);
   }
-}
+
+  function onPriceLayout(event: OnLayout) {
+    setPriceWidth(event.nativeEvent.layout.width);
+  }
+
+  const maxWidth =
+    containerWidth != null && priceWidth != null
+      ? containerWidth - priceWidth - SPACING
+      : 0;
+
+  return (
+    <View style={styles.row} onLayout={onContainerLayout}>
+      <Text style={[styles.text, { maxWidth }]} numberOfLines={1}>
+        {text}
+      </Text>
+      <View onLayout={onPriceLayout}>
+        <Text style={styles.price}>{price}</Text>
+      </View>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   row: {
@@ -73,4 +61,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default withDimensions(SummaryRow);
+export default SummaryRow;


### PR DESCRIPTION
This fixes https://github.com/kiwicom/mobile/issues/1607

The issue was that using the `withDimension` HOC meant using the dimensions of the device. On Tablet view, the RoomSummary component is displayed only on half the screen width while SummaryRow assumed there is the full width of the device to render the text. This caused the row to go out of the container if the name of the hotel room was too long on Tablet.

The SummaryRow component was refactored to use two onLayout event listeners so that both the width of the container of the row and the width of the price tag are computed, and the max width for text can be deduced from that.