### PR TITLE
Shared: Fix android toast swipe

### DIFF
--- a/android/app/src/main/java/com/reactnativeapp/MainActivity.java
+++ b/android/app/src/main/java/com/reactnativeapp/MainActivity.java
@@ -6,14 +6,16 @@ import com.facebook.FacebookSdk;
 import com.facebook.react.ReactActivity;
 import com.trinerdis.skypicker.logging.configuration.*;
 import com.trinerdis.skypicker.logging.sender.EventSender;
-
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 import java.util.ArrayList;
 
 public class MainActivity extends ReactActivity {
 
     /**
-     * Returns the name of the main component registered from JavaScript.
-     * This is used to schedule rendering of the component.
+     * Returns the name of the main component registered from JavaScript. This is
+     * used to schedule rendering of the component.
      */
     @Override
     protected String getMainComponentName() {
@@ -33,18 +35,18 @@ public class MainActivity extends ReactActivity {
         DeviceInfo deviceInfo = new DeviceInfo();
         UserInfo userInfo = new UserInfo();
 
-        EventSender.defaultInitialize(
-          getApplication(),
-          PreferenceManager.getDefaultSharedPreferences(this),
-          deviceInfo,
-          userInfo,
-          new String[]{},
-          "123456",
-          new ArrayList<>(),
-          BuildConfig.DEBUG,
-          BuildConfig.DEBUG,
-          BuildConfig.DEBUG,
-          null
-        );
+        EventSender.defaultInitialize(getApplication(), PreferenceManager.getDefaultSharedPreferences(this), deviceInfo,
+                userInfo, new String[] {}, "123456", new ArrayList<>(), BuildConfig.DEBUG, BuildConfig.DEBUG,
+                BuildConfig.DEBUG, null);
+    }
+
+    @Override
+    protected ReactActivityDelegate createReactActivityDelegate() {
+        return new ReactActivityDelegate(this, getMainComponentName()) {
+            @Override
+            protected ReactRootView createRootView() {
+                return new RNGestureHandlerEnabledRootView(MainActivity.this);
+            }
+        };
     }
 }

--- a/app/hotels/src/allHotels/RenderSearchResults.js
+++ b/app/hotels/src/allHotels/RenderSearchResults.js
@@ -95,7 +95,9 @@ export const RenderSearchResults = (props: Props) => {
     }
     if (show === 'list') {
       animateToList();
-      setShouldRenderMap(false);
+      InteractionManager.runAfterInteractions(() => {
+        setShouldRenderMap(false);
+      });
     } else {
       animateToMap();
       InteractionManager.runAfterInteractions(() => {

--- a/app/hotels/src/navigation/allHotels/navigationOptions/NavigationOptions.js
+++ b/app/hotels/src/navigation/allHotels/navigationOptions/NavigationOptions.js
@@ -8,13 +8,19 @@ import HeaderLeft from './HeaderLeft';
 import HeaderRight from './HeaderRight';
 
 export default function getNavigationOptions() {
+  const statusBarHeight = Platform.select({
+    ios: 0,
+    android: StatusBar.currentHeight,
+  });
   return {
     headerStyle: {
-      height: 78,
-      marginTop: Platform.select({
+      height: 78 + statusBarHeight,
+      marginTop: 0,
+      paddingTop: Platform.select({
         ios: 0,
-        android: StatusBar.currentHeight,
+        android: statusBarHeight,
       }),
+
       borderBottomColor: defaultTokens.paletteInkLighter,
     },
     headerLeft: <HeaderLeft />,


### PR DESCRIPTION
The toast became visible above the header.
Changed marginTop to paddingTop to prevent this behaviour.
React-native-gesture-handler was not set up correctly, fix that also(in dev)
Note it will not work in production until we fix it in RNHotelsActivity.kt
and deploy a new framework