### PR TITLE
codeowners: Set Blackhex as codeowner of rnkiwimobile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,6 @@
 # be requested for review when someone opens a pull request.
 
 * @tbergq @RobinCsl
+
+# This is code that goes into the kiwicom-native app.
+/android/rnkiwimobile/ @Blackhex 


### PR DESCRIPTION
This code goes into production, so it makes sense to have
review from someone on the android team