### PR TITLE
accounts: Prepare price alerts screen

### DIFF
--- a/android/playground/src/main/AndroidManifest.xml
+++ b/android/playground/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
         </activity>
         <activity android:name=".HotelsStay22Activity" />
         <activity android:name="com.kiwi.mobile.rnandroidplayground.AccountSettingsActivity" />
+        <activity android:name="com.kiwi.mobile.rnandroidplayground.AccountPriceAlertsActivity" />
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 

--- a/android/playground/src/main/java/com/kiwi/mobile/rnandroidplayground/AccountPriceAlertsActivity.kt
+++ b/android/playground/src/main/java/com/kiwi/mobile/rnandroidplayground/AccountPriceAlertsActivity.kt
@@ -1,0 +1,22 @@
+package com.kiwi.mobile.rnandroidplayground
+
+import android.content.pm.ActivityInfo
+import android.os.Bundle
+import com.facebook.react.ReactInstanceManager
+import com.kiwi.rnkiwimobile.account.RNAccountPriceAlertsActivity
+import com.kiwi.rnkiwimobile.account.RNAccountInitialProperties
+
+class AccountPriceAlertsActivity : RNAccountPriceAlertsActivity(RNAccountInitialProperties(token = "mock")) {
+    companion object {
+        fun getViewModelClass(): Class<AccountPriceAlertsActivity> =
+                AccountPriceAlertsActivity::class.java
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
+
+    override fun getReactNativeInstanceManager(): ReactInstanceManager = (application as PlaygroundApplication).reactNativeHost.reactInstanceManager
+
+}

--- a/android/playground/src/main/java/com/kiwi/mobile/rnandroidplayground/AccountSettingsActivity.kt
+++ b/android/playground/src/main/java/com/kiwi/mobile/rnandroidplayground/AccountSettingsActivity.kt
@@ -3,10 +3,10 @@ package com.kiwi.mobile.rnandroidplayground
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import com.facebook.react.ReactInstanceManager
-import com.kiwi.rnkiwimobile.account.RNAccountActivity
+import com.kiwi.rnkiwimobile.account.RNAccountSettingsActivity
 import com.kiwi.rnkiwimobile.account.RNAccountInitialProperties
 
-class AccountSettingsActivity : RNAccountActivity(RNAccountInitialProperties(token = "mock")) {
+class AccountSettingsActivity : RNAccountSettingsActivity(RNAccountInitialProperties(token = "mock")) {
   companion object {
     fun getViewModelClass(): Class<AccountSettingsActivity> =
             AccountSettingsActivity::class.java

--- a/android/playground/src/main/java/com/kiwi/mobile/rnandroidplayground/MainActivity.kt
+++ b/android/playground/src/main/java/com/kiwi/mobile/rnandroidplayground/MainActivity.kt
@@ -27,6 +27,10 @@ class MainActivity : AppCompatActivity() {
     button_account_settings.setOnClickListener {
       startActivity(Intent(this, AccountSettingsActivity.getViewModelClass()))
     }
+
+    button_account_price_alerts.setOnClickListener {
+      startActivity(Intent(this, AccountPriceAlertsActivity.getViewModelClass()))
+    }
   }
 
   override fun onDestroy() {

--- a/android/playground/src/main/res/layout/activity_main.xml
+++ b/android/playground/src/main/res/layout/activity_main.xml
@@ -33,4 +33,10 @@
         android:layout_height="wrap_content"
         android:text="Account Settings"/>
 
+    <Button
+        android:id="@+id/button_account_price_alerts"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Account price alerts" />
+
 </LinearLayout>

--- a/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountActivity.kt
+++ b/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountActivity.kt
@@ -1,9 +1,0 @@
-package com.kiwi.rnkiwimobile.account
-
-import com.kiwi.rnkiwimobile.RNKiwiActivity
-
-abstract class RNAccountActivity(initialProperties: RNAccountInitialProperties) :RNKiwiActivity(RNAccountModule.getInitialProperties(initialProperties)) {
-    override fun getModuleName(): String {
-        return RNAccountModule.moduleName
-    }
-}

--- a/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountModule.kt
+++ b/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountModule.kt
@@ -9,7 +9,6 @@ import com.reactnativecommunity.asyncstorage.AsyncStoragePackage;
 
 object RNAccountModule {
     const val jsEntryPoint = "app/native.js"
-    const val moduleName = "AccountSettings"
 
     fun getPackages(): MutableList<ReactPackage> {
         return mutableListOf(RNGestureHandlerPackage())

--- a/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountPriceAlertsActivity.kt
+++ b/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountPriceAlertsActivity.kt
@@ -1,0 +1,9 @@
+package com.kiwi.rnkiwimobile.account
+
+import com.kiwi.rnkiwimobile.RNKiwiActivity
+
+abstract class RNAccountPriceAlertsActivity(initialProperties: RNAccountInitialProperties) : RNKiwiActivity(RNAccountModule.getInitialProperties(initialProperties)) {
+    override fun getModuleName(): String {
+        return "AccountPriceAlerts"
+    }
+}

--- a/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountSettingsActivity.kt
+++ b/android/rnkiwimobile/src/main/java/com/kiwi/rnkiwimobile/account/RNAccountSettingsActivity.kt
@@ -1,0 +1,9 @@
+package com.kiwi.rnkiwimobile.account
+
+import com.kiwi.rnkiwimobile.RNKiwiActivity
+
+abstract class RNAccountSettingsActivity(initialProperties: RNAccountInitialProperties) : RNKiwiActivity(RNAccountModule.getInitialProperties(initialProperties)) {
+    override fun getModuleName(): String {
+        return "AccountSettings"
+    }
+}

--- a/app/account/index.js
+++ b/app/account/index.js
@@ -1,3 +1,4 @@
 // @flow
 
 export { default as AccountSettings } from './src/appRegistry/AccountSettings';
+export { default as AccountPriceAlerts } from './src/appRegistry/PriceAlerts';

--- a/app/account/src/TodoScreen.js
+++ b/app/account/src/TodoScreen.js
@@ -1,0 +1,18 @@
+// @flow strict
+
+import * as React from 'react';
+import { View, Platform } from 'react-native';
+import { Translation } from '@kiwicom/mobile-shared';
+
+export default function TodoScreen() {
+  const navigationInfo = Platform.select({
+    ios: 'Please swipe to navigate back',
+    android: 'Please use android back button to navigate back',
+  });
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Translation passThrough="This screen is under development" />
+      <Translation passThrough={navigationInfo} />
+    </View>
+  );
+}

--- a/app/account/src/WithAccountStack.js
+++ b/app/account/src/WithAccountStack.js
@@ -1,0 +1,32 @@
+// @flow strict
+
+import * as React from 'react';
+import { View, StatusBar } from 'react-native';
+import { StyleSheet } from '@kiwicom/mobile-shared';
+import { AppProvider } from '@kiwicom/account-native';
+
+type Props = {|
+  +onBackClicked: () => void,
+  +token: string,
+  +children: React.Node,
+|};
+
+export default function WithAccountStack(props: Props) {
+  return (
+    <View style={styles.container}>
+      <AppProvider onBackPressed={props.onBackClicked} token={props.token}>
+        {props.children}
+      </AppProvider>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 0,
+    android: {
+      paddingTop: StatusBar.currentHeight, // This was for some reason not added correctly by react-navigation 🤔
+    },
+  },
+});

--- a/app/account/src/appRegistry/PriceAlerts.js
+++ b/app/account/src/appRegistry/PriceAlerts.js
@@ -2,23 +2,22 @@
 
 import * as React from 'react';
 import { WithNativeNavigation } from '@kiwicom/mobile-shared';
-import { Settings as AccountSettingsStack } from '@kiwicom/account-native';
 
 import WithAccountStack from '../WithAccountStack';
+import TodoScreen from '../TodoScreen';
 
 type Props = {|
   +onBackClicked: () => void,
   +token: string,
 |};
 
-class AccountSettings extends React.Component<Props> {
+class PriceAlerts extends React.Component<Props> {
   render() {
     return (
       <WithAccountStack {...this.props}>
-        <AccountSettingsStack />
+        <TodoScreen />
       </WithAccountStack>
     );
   }
 }
-
-export default WithNativeNavigation(AccountSettings, 'AccountSettings');
+export default WithNativeNavigation(PriceAlerts, 'AccountPriceAlerts');

--- a/app/native.js
+++ b/app/native.js
@@ -7,7 +7,7 @@ import {
   NewHotelsStandAlonePackage,
 } from '@kiwicom/react-native-app-hotels';
 import { AncillaryFactory } from '@kiwicom/react-native-ancillary-factory';
-import { AccountSettings } from '@kiwicom/mobile-account';
+import { AccountSettings, AccountPriceAlerts } from '@kiwicom/mobile-account';
 
 // Hotels
 AppRegistry.registerComponent('NewKiwiHotels', () => NewHotelsStandAlonePackage);
@@ -18,6 +18,7 @@ AppRegistry.registerComponent('AncillaryFactory', () => AncillaryFactory);
 
 // Account
 AppRegistry.registerComponent('AccountSettings', () => AccountSettings);
+AppRegistry.registerComponent('AccountPriceAlerts', () => AccountPriceAlerts);
 
 // This file is only used for native integration and we use CodePush there
 CodePush.sync({

--- a/ios/RNNativePlayground/Base.lproj/Main.storyboard
+++ b/ios/RNNativePlayground/Base.lproj/Main.storyboard
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QHj-7e-Fcl">
-                                <rect key="frame" x="88.5" y="318.5" width="198" height="30"/>
+                                <rect key="frame" x="88.5" y="273.5" width="198" height="120"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="MyC-DG-EB7">
-                                        <rect key="frame" x="0.0" y="0.0" width="198" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="198" height="120"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s16-m2-Q3f">
                                                 <rect key="frame" x="0.0" y="0.0" width="198" height="30"/>
@@ -31,51 +31,55 @@
                                                     <action selector="presentNewHotelsView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8CQ-mt-YBh"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mO0-5n-Vye">
+                                                <rect key="frame" x="0.0" y="30" width="198" height="30"/>
+                                                <state key="normal" title="Present stay22"/>
+                                                <connections>
+                                                    <action selector="present22stay:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ujy-xz-cvG"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="72D-Ig-efP">
+                                                <rect key="frame" x="0.0" y="60" width="198" height="30"/>
+                                                <state key="normal" title="Push account settings"/>
+                                                <connections>
+                                                    <action selector="pushAccountsView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UKq-mA-4Cf"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xdj-Gt-WLn">
+                                                <rect key="frame" x="0.0" y="90" width="198" height="30"/>
+                                                <state key="normal" title="Push price alerts"/>
+                                                <connections>
+                                                    <action selector="pushPriceAlerts:" destination="BYZ-38-t0r" eventType="touchUpInside" id="d10-QU-dJB"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select start date" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="aMy-op-KJ7">
-                                <rect key="frame" x="16" y="204.5" width="343" height="30"/>
+                                <rect key="frame" x="16" y="159.5" width="343" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select end date" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oID-K6-8uc">
-                                <rect key="frame" x="16" y="242.5" width="343" height="30"/>
+                                <rect key="frame" x="16" y="197.5" width="343" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select city" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QBX-BO-IRW">
-                                <rect key="frame" x="16" y="280.5" width="343" height="30"/>
+                                <rect key="frame" x="16" y="235.5" width="343" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mO0-5n-Vye">
-                                <rect key="frame" x="136" y="356.5" width="103" height="30"/>
-                                <state key="normal" title="Present stay22"/>
-                                <connections>
-                                    <action selector="present22stay:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ujy-xz-cvG"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="72D-Ig-efP">
-                                <rect key="frame" x="136" y="461" width="101" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Push accounts"/>
-                                <connections>
-                                    <action selector="pushAccountsView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UKq-mA-4Cf"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="aMy-op-KJ7" firstAttribute="trailing" secondItem="oID-K6-8uc" secondAttribute="trailing" id="0Xz-io-xA3"/>
-                            <constraint firstItem="mO0-5n-Vye" firstAttribute="top" secondItem="QHj-7e-Fcl" secondAttribute="bottom" constant="8" symbolic="YES" id="1Sl-QI-Jm4"/>
                             <constraint firstItem="aMy-op-KJ7" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="2cH-kL-jFd"/>
                             <constraint firstItem="oID-K6-8uc" firstAttribute="trailing" secondItem="QBX-BO-IRW" secondAttribute="trailing" id="Agw-z8-gP9"/>
-                            <constraint firstItem="mO0-5n-Vye" firstAttribute="centerX" secondItem="QHj-7e-Fcl" secondAttribute="centerX" id="DaK-IS-uUf"/>
                             <constraint firstItem="QBX-BO-IRW" firstAttribute="centerX" secondItem="QHj-7e-Fcl" secondAttribute="centerX" id="L5l-lZ-Aws"/>
                             <constraint firstItem="oID-K6-8uc" firstAttribute="leading" secondItem="QBX-BO-IRW" secondAttribute="leading" id="PeM-fb-uuH"/>
                             <constraint firstItem="QBX-BO-IRW" firstAttribute="top" secondItem="oID-K6-8uc" secondAttribute="bottom" constant="8" symbolic="YES" id="XIG-fk-LJq"/>

--- a/ios/RNNativePlayground/ViewController.m
+++ b/ios/RNNativePlayground/ViewController.m
@@ -247,6 +247,16 @@
   [[self navigationController] pushViewController:controller animated:YES];
 }
 
+- (IBAction)pushPriceAlerts:(id)sender {
+  RNKiwiViewController *controller = [[RNKiwiViewController alloc] initWithModule:@"AccountPriceAlerts"
+                                                                initialProperties:@{
+                                                                                    @"lastNavigationMode": @"push",
+                                                                                    @"token": @"mockToken",
+                                                                                    }];
+  [self setActiveViewController:controller];
+  [[self navigationController] pushViewController:controller animated:YES];
+}
+
 // Offer search is based on city ID
 - (IBAction)presentNewHotelsView:(id)sender {
   


### PR DESCRIPTION
Note: I want to prepare Also price alerts. This way, the next time we increase the framework version, it should be possible for native to access and test the accounts screens and we can keep pushing new code with code-push. 

We should release yet a new version before going to production, since there is a risk that the user will see the `under development screen` if he visits the screen before the app has downloaded the new bundle from code-push