### PR TITLE
accountDeleted method for iOS

### DIFF
--- a/.build/package.json
+++ b/.build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiwicom/react-native-app-hotels",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "private": false,
   "main": "index.js",
   "dependencies": {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - JWT (3.0.0-beta.11):
+  - JWT (3.0.0-beta.12):
     - Base64 (~> 1.1.2)
   - React (0.60.5):
     - React-Core (= 0.60.5)
@@ -148,7 +148,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - Base64
     - boost-for-react-native
     - JWT
@@ -219,7 +219,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  JWT: 05028b9624591bba9681bb57df2c5f95fa258bad
+  JWT: 9b5c05abbcc1a0e69c3c91e1655b3387fc7e581d
   React: 53c53c4d99097af47cf60594b8706b4e3321e722
   React-Core: ba421f6b4f4cbe2fb17c0b6fc675f87622e78a64
   React-cxxreact: 8384287780c4999351ad9b6e7a149d9ed10a2395
@@ -248,4 +248,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 0d3a33be0c26b65700ef25b55314f395972202ba
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/ios/RNKiwiMobile/RNKiwiAccountUpdater.h
+++ b/ios/RNKiwiMobile/RNKiwiAccountUpdater.h
@@ -1,0 +1,16 @@
+//
+//  RNKiwiAccountUpdater.h
+//  RNKiwiMobile
+//
+//  Created by Šimon Javora on 19/11/2019.
+//  Copyright © 2019 Kiwi.com. All rights reserved.
+//
+
+@import Foundation;
+#import "React/RCTBridgeModule.h"
+
+RCT_EXTERN const NSNotificationName _Nonnull RNKiwiAccountDeletedNotification;
+
+@interface RNKiwiAccountUpdater : NSObject <RCTBridgeModule>
+
+@end

--- a/ios/RNKiwiMobile/RNKiwiAccountUpdater.m
+++ b/ios/RNKiwiMobile/RNKiwiAccountUpdater.m
@@ -1,0 +1,19 @@
+//
+//  RNKiwiAccountUpdater.m
+//  RNKiwiMobile
+//
+//  Created by Šimon Javora on 19/11/2019.
+//  Copyright © 2019 Kiwi.com. All rights reserved.
+//
+
+const NSNotificationName RNKiwiAccountDeletedNotification = @"RNKiwiAccountDeletedNotification";
+
+#import "RNKiwiAccountUpdater.h"
+
+@implementation RNKiwiAccountUpdater
+
+RCT_EXPORT_METHOD(accountDeleted) {
+  [[NSNotificationCenter defaultCenter] postNotificationName:RNKiwiAccountDeletedNotification object:nil userInfo:@{}];
+}
+
+@end

--- a/ios/RNKiwiMobile/RNKiwiViewController.h
+++ b/ios/RNKiwiMobile/RNKiwiViewController.h
@@ -14,6 +14,9 @@
 @property (nonatomic, weak, nullable) id<RNKiwiTranslationProvider> translationProvider;
 @property (nonatomic, weak, nullable) id<RNKiwiViewControllerFlowDelegate> flowDelegate;
 
+// Account
+@property (nonatomic, copy, nullable) void (^didDeleteAccount)(void);
+
 // Logging
 @property (nonatomic, copy, nullable) void (^didDisplayAncillary)(NSString * _Nonnull type, NSString * _Nonnull provider);
 @property (nonatomic, copy, nullable) void (^didPurchaseAncillary)(NSString * _Nonnull type, NSString * _Nonnull provider);

--- a/ios/reactNativeApp.xcodeproj/project.pbxproj
+++ b/ios/reactNativeApp.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		27E931E420ADA0630053AE19 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 27E931E320ADA0630053AE19 /* main.m */; };
 		51A8F6BE673D4671A3545CD8 /* CircularPro-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 50EB547AC35C4D25B73F0376 /* CircularPro-Medium.otf */; };
 		60854A62F6F281394EE676B5 /* libPods-reactNativeApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0520FD3BC77D396F74CF8285 /* libPods-reactNativeApp.a */; };
+		62C5AB7D238419F1008A9678 /* RNKiwiAccountUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 62C5AB7B238419F1008A9678 /* RNKiwiAccountUpdater.h */; };
+		62C5AB7E238419F1008A9678 /* RNKiwiAccountUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 62C5AB7C238419F1008A9678 /* RNKiwiAccountUpdater.m */; };
 		632F9458230D451A007D857E /* CircularPro-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 71A4A2C5C6994635AF8475F2 /* CircularPro-Bold.otf */; };
 		632F9459230D451A007D857E /* CircularPro-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 50EB547AC35C4D25B73F0376 /* CircularPro-Medium.otf */; };
 		63497BE72306A93D0006DC8B /* Roboto.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 63497BE62306A93D0006DC8B /* Roboto.ttf */; };
@@ -137,6 +139,8 @@
 		34003FC5EE453F3F2C072F56 /* libPods-RNNativePlayground.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNNativePlayground.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		50EB547AC35C4D25B73F0376 /* CircularPro-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "CircularPro-Medium.otf"; path = "../assets/fonts/ios/CircularPro-Medium.otf"; sourceTree = "<group>"; };
 		5EF541A9996B4D6AB8AEDA5B /* Roboto-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-Bold.ttf"; path = "../assets/fonts/android/Roboto-Bold.ttf"; sourceTree = "<group>"; };
+		62C5AB7B238419F1008A9678 /* RNKiwiAccountUpdater.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNKiwiAccountUpdater.h; sourceTree = "<group>"; };
+		62C5AB7C238419F1008A9678 /* RNKiwiAccountUpdater.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNKiwiAccountUpdater.m; sourceTree = "<group>"; };
 		63497BE62306A93D0006DC8B /* Roboto.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = Roboto.ttf; path = "../node_modules/@kiwicom/account-native/apps/account-native/assets/fonts/Roboto/Roboto.ttf"; sourceTree = "<group>"; };
 		63738758220D81E600665942 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		63A8419C20C853840093183F /* Social.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Social.framework; path = System/Library/Frameworks/Social.framework; sourceTree = SDKROOT; };
@@ -230,6 +234,8 @@
 				686E005020B2E24B0013512F /* RNKiwiConstants.m */,
 				2107154520B5677200E6C96B /* RNKiwiGestureController.h */,
 				2107154420B5677200E6C96B /* RNKiwiGestureController.m */,
+				62C5AB7B238419F1008A9678 /* RNKiwiAccountUpdater.h */,
+				62C5AB7C238419F1008A9678 /* RNKiwiAccountUpdater.m */,
 				2711986D20B2A0C100C6292B /* RNKiwiSharedBridge.h */,
 				2711986E20B2A0C100C6292B /* RNKiwiSharedBridge.m */,
 				27E931BE20AD987C0053AE19 /* RNKiwiViewController.h */,
@@ -335,6 +341,7 @@
 				27E931C720AD9A620053AE19 /* RNKiwiTranslationProvider.h in Headers */,
 				2107154720B5677200E6C96B /* RNKiwiGestureController.h in Headers */,
 				27E931C320AD9A2A0053AE19 /* RNKiwiViewControllerFlowDelegate.h in Headers */,
+				62C5AB7D238419F1008A9678 /* RNKiwiAccountUpdater.h in Headers */,
 				27E931C520AD9A4B0053AE19 /* RNKiwiCurrencyManager.h in Headers */,
 				2711986F20B2A0C100C6292B /* RNKiwiSharedBridge.h in Headers */,
 				686E004B20B2E1360013512F /* RNKiwiConstants.h in Headers */,
@@ -627,6 +634,7 @@
 				27E931C120AD987C0053AE19 /* RNKiwiViewController.m in Sources */,
 				2711987020B2A0C100C6292B /* RNKiwiSharedBridge.m in Sources */,
 				686E005120B2E24B0013512F /* RNKiwiConstants.m in Sources */,
+				62C5AB7E238419F1008A9678 /* RNKiwiAccountUpdater.m in Sources */,
 				2107154620B5677200E6C96B /* RNKiwiGestureController.m in Sources */,
 				9399D42C226F18B6005C0F67 /* AncillaryViewController.m in Sources */,
 			);

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test-runner": "jest"
   },
   "rnkiwimobile": {
-    "code-push-target-binary-version": "15.0.0"
+    "code-push-target-binary-version": "16.0.0"
   },
   "resolutions": {
     "@kiwicom/relay": "4.7.1"


### PR DESCRIPTION
Add RNKiwiAccountUpdater to expose `accountDeleted` method to JS. Add `didDeleteAccount` property to react (ha) to account deletion in iOS app.