### PR TITLE
Fix DeviceLocale for android

### DIFF
--- a/packages/localization/src/GetDeviceLocale.android.js
+++ b/packages/localization/src/GetDeviceLocale.android.js
@@ -1,0 +1,20 @@
+// @flow strict
+
+import { NativeModules } from 'react-native';
+
+const locale = NativeModules.RNDeviceInfo.Locale; // e.g. en-US
+const [language, territory] = locale.split('-');
+
+export const getLanguage = () => language;
+export const getTerritory = () => territory;
+export const getLocaleUnderscored = () => locale.replace('-', '_');
+export const getLocaleDashed = () => locale;
+
+const DeviceLocale = {
+  getLanguage,
+  getTerritory,
+  getLocaleUnderscored,
+  getLocaleDashed,
+};
+
+export default DeviceLocale;


### PR DESCRIPTION
Android native module only return Locale like `en-GB`
So we have to parse this in JS for it to work as it does on iOS