### PR TITLE
fix(localization): Fix typo in Hotels' translations

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "adeira/valid-test-folder": "off"
+  }
+}

--- a/e2e/hotels/hotelDetails/notEnoughBeds.spec.js
+++ b/e2e/hotels/hotelDetails/notEnoughBeds.spec.js
@@ -27,9 +27,7 @@ describe('Hotel detail - Not enough beds warning', () => {
     await pressBookNow();
 
     await expect(
-      element(
-        by.label("Thats's fine").and(by.type('_UIAlertControllerActionView')),
-      ),
+      element(by.label("That's fine").and(by.type('_UIAlertControllerActionView'))),
     ).toBeVisible();
   });
 });

--- a/packages/localization/src/vocabularies/Hotels.js
+++ b/packages/localization/src/vocabularies/Hotels.js
@@ -78,7 +78,7 @@ const HotelsVocabulary = {
   'single_hotel.book_now.alert_title': 'Not enough beds for everyone',
   'single_hotel.book_now.alert_body':
     'Your selection accommodates less than __numberOfGuests__ persons',
-  'single_hotel.book_now.alert_ok': "Thats's fine",
+  'single_hotel.book_now.alert_ok': "That's fine",
   'single_hotel.description.facilities.show_less': 'Show less',
   'single_hotel.description.facilities.show_more': 'More',
   'single_hotel.hotel_detail_screen.hotel_not_found': 'Hotel not found.',


### PR DESCRIPTION
This commit also silences ESLint warnings in `e2e/` folder for the rule `adeira/valid-test-folder` as that folder only contains tests: it would be redundant to create a `__tests__/` folder for each subfolder in `e2e/`.